### PR TITLE
External Auth - Create, Update , Enable and Disable API methods for Users.

### DIFF
--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -1,24 +1,24 @@
 <?php
 
 /*
- * This file is part of SeAT
- *
- * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
+* This file is part of SeAT
+*
+* Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program; if not, write to the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 
 namespace Seat\Api\Http\Controllers\Api\v2;
 
@@ -27,47 +27,49 @@ use Seat\Api\Http\Resources\GroupResource;
 use Seat\Api\Http\Resources\UserResource;
 use Seat\Web\Models\Group;
 use Seat\Web\Models\User;
+use Seat\Eveapi\Models\RefreshToken;
+use Illuminate\Http\Request;
 
 /**
- * Class UserController.
- * @package Seat\Api\Http\Controllers\Api\v2
- */
+* Class UserController.
+* @package Seat\Api\Http\Controllers\Api\v2
+*/
 class UserController extends Controller
 {
     /**
-     * @SWG\Get(
-     *      path="/users",
-     *      tags={"Users"},
-     *      summary="Get a list of users, associated character id's and group ids",
-     *      description="Returns list of users",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @SWG\Get(
-     *      path="/users/{user_id}",
-     *      tags={"Users"},
-     *      summary="Get group id's and assosciated character_id's for a user",
-     *      description="Returns a user",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Parameter(
-     *          name="user_id",
-     *          description="User id",
-     *          required=true,
-     *          type="integer",
-     *          in="path"
-     *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @param null $user_id
-     *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-     */
+    * @SWG\Get(
+    *      path="/users",
+    *      tags={"Users"},
+    *      summary="Get a list of users, associated character id's and group ids",
+    *      description="Returns list of users",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @SWG\Get(
+    *      path="/users/{user_id}",
+    *      tags={"Users"},
+    *      summary="Get group id's and assosciated character_id's for a user",
+    *      description="Returns a user",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Parameter(
+    *          name="user_id",
+    *          description="User id",
+    *          required=true,
+    *          type="integer",
+    *          in="path"
+    *      ),
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @param null $user_id
+    *
+    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    */
     public function getUsers($user_id = null)
     {
 
@@ -78,39 +80,39 @@ class UserController extends Controller
     }
 
     /**
-     * @SWG\Get(
-     *      path="/users/groups",
-     *      tags={"Users"},
-     *      summary="Get a list of groups with their associated character_id's",
-     *      description="Returns list of groups",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @SWG\Get(
-     *      path="/users/groups/{group_id}",
-     *      tags={"Users"},
-     *      summary="Get a group with its associated character_id's",
-     *      description="Returns a group",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Parameter(
-     *          name="group_id",
-     *          description="Group id",
-     *          required=true,
-     *          type="integer",
-     *          in="path"
-     *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @param null $group_id
-     *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-     */
+    * @SWG\Get(
+    *      path="/users/groups",
+    *      tags={"Users"},
+    *      summary="Get a list of groups with their associated character_id's",
+    *      description="Returns list of groups",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @SWG\Get(
+    *      path="/users/groups/{group_id}",
+    *      tags={"Users"},
+    *      summary="Get a group with its associated character_id's",
+    *      description="Returns a group",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Parameter(
+    *          name="group_id",
+    *          description="Group id",
+    *          required=true,
+    *          type="integer",
+    *          in="path"
+    *      ),
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @param null $group_id
+    *
+    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    */
     public function getGroups($group_id = null)
     {
 
@@ -118,5 +120,93 @@ class UserController extends Controller
             return new GroupResource(Group::findOrFail($group_id));
 
         return GroupResource::collection(Group::all());
+    }
+
+    /**
+    *
+    * @SWG\Post(
+    *      path="/users/new",
+    *      tags={"Users"},
+    *      summary="Create a New user",
+    *      description="Creates a New Users and refreshToken",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Parameter(
+    *          name="user_id",
+    *          description="User id",
+    *          required=true,
+    *          type="integer",
+    *          in="path"
+    *      ),
+    *     @SWG\Parameter(
+    *          name="group_id",
+    *          description="Group id",
+    *          required=true,
+    *          type="integer",
+    *          in="path"
+    *      ),
+    *     @SWG\Parameter(
+    *          name="name",
+    *          description="Character Name",
+    *          required=true,
+    *          type="string",
+    *          in="path"
+    *      ),
+    *     @SWG\Parameter(
+    *          name="hash",
+    *          description="Character Owner Hash",
+    *          required=true,
+    *          type="string",
+    *          in="path"
+    *      ),
+    *     @SWG\Parameter(
+    *          name="refresh_token",
+    *          description="A Valid Refresh Token",
+    *          required=true,
+    *          type="string",
+    *          in="path"
+    *      ),
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @param null $user_id
+    *
+    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    */
+
+    public function postNew(Request $request)
+    {
+        $id         = $request->input('id');
+        $group_id   = $request->input('group_id');
+        $name       = $request->input('name');
+        $active     = true;
+        $hash       = $request->input('hash');
+
+        $user = User::forceCreate([  // id is not fillable
+            'id'                   => $id,
+            'group_id'             => $group_id,
+            'name'                 => $name,
+            'active'               => true,
+            'character_owner_hash' => $hash,
+        ]);
+
+
+        $character_id   = $request->input('id');
+        $refresh_token  = $request->input('refresh_token');
+        $scopes         = setting('sso_scopes', true);
+        $expires_on     = '1980-01-01 00:00:00';
+        $token          = '-';
+
+        DebugBreak();
+        $userRefreshToken = RefreshToken::firstorCreate(
+            ['character_id' => $character_id],
+            ['refresh_token'=> $refresh_token,
+            'scopes'=>$scopes,
+            'expires_on'=>$expires_on,
+            'token'=>$token]
+        );
+
+        return response()->json(['id' => $user->id]);
     }
 }

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -31,45 +31,45 @@ use Seat\Web\Models\Group;
 use Seat\Web\Models\User;
 
 /**
-* Class UserController.
-* @package Seat\Api\Http\Controllers\Api\v2
-*/
+ * Class UserController.
+ * @package Seat\Api\Http\Controllers\Api\v2
+ */
 class UserController extends Controller
 {
     /**
-    * @SWG\Get(
-    *      path="/users",
-    *      tags={"Users"},
-    *      summary="Get a list of users, associated character id's and group ids",
-    *      description="Returns list of users",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @SWG\Get(
-    *      path="/users/{user_id}",
-    *      tags={"Users"},
-    *      summary="Get group id's and assosciated character_id's for a user",
-    *      description="Returns a user",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Parameter(
-    *          name="user_id",
-    *          description="User id",
-    *          required=true,
-    *          type="integer",
-    *          in="path"
-    *      ),
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @param null $user_id
-    *
-    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-    */
+     * @SWG\Get(
+     *      path="/users",
+     *      tags={"Users"},
+     *      summary="Get a list of users, associated character id's and group ids",
+     *      description="Returns list of users",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @SWG\Get(
+     *      path="/users/{user_id}",
+     *      tags={"Users"},
+     *      summary="Get group id's and assosciated character_id's for a user",
+     *      description="Returns a user",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Parameter(
+     *          name="user_id",
+     *          description="User id",
+     *          required=true,
+     *          type="integer",
+     *          in="path"
+     *      ),
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @param null $user_id
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
     public function getUsers($user_id = null)
     {
 
@@ -80,39 +80,39 @@ class UserController extends Controller
     }
 
     /**
-    * @SWG\Get(
-    *      path="/users/groups",
-    *      tags={"Users"},
-    *      summary="Get a list of groups with their associated character_id's",
-    *      description="Returns list of groups",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @SWG\Get(
-    *      path="/users/groups/{group_id}",
-    *      tags={"Users"},
-    *      summary="Get a group with its associated character_id's",
-    *      description="Returns a group",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Parameter(
-    *          name="group_id",
-    *          description="Group id",
-    *          required=true,
-    *          type="integer",
-    *          in="path"
-    *      ),
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @param null $group_id
-    *
-    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-    */
+     * @SWG\Get(
+     *      path="/users/groups",
+     *      tags={"Users"},
+     *      summary="Get a list of groups with their associated character_id's",
+     *      description="Returns list of groups",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @SWG\Get(
+     *      path="/users/groups/{group_id}",
+     *      tags={"Users"},
+     *      summary="Get a group with its associated character_id's",
+     *      description="Returns a group",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Parameter(
+     *          name="group_id",
+     *          description="Group id",
+     *          required=true,
+     *          type="integer",
+     *          in="path"
+     *      ),
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @param null $group_id
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
     public function getGroups($group_id = null)
     {
 
@@ -123,70 +123,70 @@ class UserController extends Controller
     }
 
     /**
-    * @SWG\Post(
-    *      path="/users/new",
-    *      tags={"Users"},
-    *      summary="Create or update a user",
-    *      description="Creates or Updates Users and refreshTokens",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Parameter(
-    *          name="user_id",
-    *          description="Eve Online Character ID",
-    *          required=true,
-    *          in="body",
-    *          @SWG\Schema(type="integer")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="group_id",
-    *          description="Group id. If ommited a new group is created",
-    *          required=false,
-    *          in="body",
-    *          @SWG\Schema(type="integer")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="name",
-    *          description="Eve Online Character Name",
-    *          required=true,
-    *          in="body",
-    *          @SWG\Schema(type="string")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="active",
-    *          description="Seat Account Active. Default True",
-    *          required=false,
-    *          in="body",
-    *          @SWG\Schema(type="boolean")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="hash",
-    *          description="Character Owner Hash",
-    *          required=true,
-    *          in="body",
-    *          @SWG\Schema(type="string")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="refresh_token",
-    *          description="A valid Refresh Token",
-    *          required=true,
-    *          in="body",
-    *          @SWG\Schema(type="string")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="scopes",
-    *          description="ESI Scopes for refreshToken. Defaults to Seat Scopes",
-    *          required=false,
-    *          in="body",
-    *          @SWG\Schema(type="json")
-    *      ),
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @param null $user_id
-    *
-    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-    */
+     * @SWG\Post(
+     *      path="/users/new",
+     *      tags={"Users"},
+     *      summary="Create or update a user",
+     *      description="Creates or Updates Users and refreshTokens",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Parameter(
+     *          name="user_id",
+     *          description="Eve Online Character ID",
+     *          required=true,
+     *          in="body",
+     *          @SWG\Schema(type="integer")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="group_id",
+     *          description="Group id. If ommited a new group is created",
+     *          required=false,
+     *          in="body",
+     *          @SWG\Schema(type="integer")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="name",
+     *          description="Eve Online Character Name",
+     *          required=true,
+     *          in="body",
+     *          @SWG\Schema(type="string")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="active",
+     *          description="Seat Account Active. Default True",
+     *          required=false,
+     *          in="body",
+     *          @SWG\Schema(type="boolean")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="hash",
+     *          description="Character Owner Hash",
+     *          required=true,
+     *          in="body",
+     *          @SWG\Schema(type="string")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="refresh_token",
+     *          description="A valid Refresh Token",
+     *          required=true,
+     *          in="body",
+     *          @SWG\Schema(type="string")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="scopes",
+     *          description="ESI Scopes for refreshToken. Defaults to Seat Scopes",
+     *          required=false,
+     *          in="body",
+     *          @SWG\Schema(type="json")
+     *      ),
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @param null $user_id
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
     public function postNew(Request $request)
     {
 
@@ -233,71 +233,70 @@ class UserController extends Controller
     }
 
     /**
-    * @SWG\Post(
-    *      path="/users/enable/{user_id}",
-    *      tags={"Users"},
-    *      summary="Enable a user",
-    *      description="Enables a User Account",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Parameter(
-    *          name="user_id",
-    *          description="Eve Online Character ID",
-    *          required=true,
-    *          in="path",
-    *          type="integer"
-    *      ),
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @param null $user_id
-    *
-    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-    */
+     * @SWG\Post(
+     *      path="/users/enable/{user_id}",
+     *      tags={"Users"},
+     *      summary="Enable a user",
+     *      description="Enables a User Account",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Parameter(
+     *          name="user_id",
+     *          description="Eve Online Character ID",
+     *          required=true,
+     *          in="path",
+     *          type="integer"
+     *      ),
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @param null $user_id
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function postEnable($user_id = null) {
 
-    public function postEnable($user_id=null){
-        
         $user = User::find($user_id);
         if (is_null($user)) return response()->json(['OK'=>false]);
         $user->active = true;
         $user->save();
+
         return response()->json(['OK'=>true]);
 
     }
 
     /**
-    * @SWG\Post(
-    *      path="/users/disable/{user_id}",
-    *      tags={"Users"},
-    *      summary="Disable User",
-    *      description="Disables a User Account",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Parameter(
-    *          name="user_id",
-    *          description="Eve Online Character ID",
-    *          required=true,
-    *          in="path",
-    *          type="integer"
-    *      ),
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @param null $user_id
-    *
-    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-    */
-
-    public function postDisable($user_id=null){
+     * @SWG\Post(
+     *      path="/users/disable/{user_id}",
+     *      tags={"Users"},
+     *      summary="Disable User",
+     *      description="Disables a User Account",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Parameter(
+     *          name="user_id",
+     *          description="Eve Online Character ID",
+     *          required=true,
+     *          in="path",
+     *          type="integer"
+     *      ),
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @param null $user_id
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function postDisable($user_id = null) {
 
         $user = User::find($user_id);
         if (is_null($user)) return response()->json(['OK'=>false]);
         $user->active = false;
         $user->save();
+
         return response()->json(['OK'=>true]);
 
     }
-
 }

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -22,54 +22,54 @@
 
 namespace Seat\Api\Http\Controllers\Api\v2;
 
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Seat\Api\Http\Resources\GroupResource;
 use Seat\Api\Http\Resources\UserResource;
+use Seat\Eveapi\Models\RefreshToken;
 use Seat\Web\Models\Group;
 use Seat\Web\Models\User;
-use Seat\Eveapi\Models\RefreshToken;
-use Illuminate\Http\Request;
 
 /**
-* Class UserController.
-* @package Seat\Api\Http\Controllers\Api\v2
-*/
+ * Class UserController.
+ * @package Seat\Api\Http\Controllers\Api\v2
+ */
 class UserController extends Controller
 {
     /**
-    * @SWG\Get(
-    *      path="/users",
-    *      tags={"Users"},
-    *      summary="Get a list of users, associated character id's and group ids",
-    *      description="Returns list of users",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @SWG\Get(
-    *      path="/users/{user_id}",
-    *      tags={"Users"},
-    *      summary="Get group id's and assosciated character_id's for a user",
-    *      description="Returns a user",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Parameter(
-    *          name="user_id",
-    *          description="User id",
-    *          required=true,
-    *          type="integer",
-    *          in="path"
-    *      ),
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @param null $user_id
-    *
-    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-    */
+     * @SWG\Get(
+     *      path="/users",
+     *      tags={"Users"},
+     *      summary="Get a list of users, associated character id's and group ids",
+     *      description="Returns list of users",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @SWG\Get(
+     *      path="/users/{user_id}",
+     *      tags={"Users"},
+     *      summary="Get group id's and assosciated character_id's for a user",
+     *      description="Returns a user",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Parameter(
+     *          name="user_id",
+     *          description="User id",
+     *          required=true,
+     *          type="integer",
+     *          in="path"
+     *      ),
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @param null $user_id
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
     public function getUsers($user_id = null)
     {
 
@@ -80,39 +80,39 @@ class UserController extends Controller
     }
 
     /**
-    * @SWG\Get(
-    *      path="/users/groups",
-    *      tags={"Users"},
-    *      summary="Get a list of groups with their associated character_id's",
-    *      description="Returns list of groups",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @SWG\Get(
-    *      path="/users/groups/{group_id}",
-    *      tags={"Users"},
-    *      summary="Get a group with its associated character_id's",
-    *      description="Returns a group",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Parameter(
-    *          name="group_id",
-    *          description="Group id",
-    *          required=true,
-    *          type="integer",
-    *          in="path"
-    *      ),
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @param null $group_id
-    *
-    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-    */
+     * @SWG\Get(
+     *      path="/users/groups",
+     *      tags={"Users"},
+     *      summary="Get a list of groups with their associated character_id's",
+     *      description="Returns list of groups",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @SWG\Get(
+     *      path="/users/groups/{group_id}",
+     *      tags={"Users"},
+     *      summary="Get a group with its associated character_id's",
+     *      description="Returns a group",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Parameter(
+     *          name="group_id",
+     *          description="Group id",
+     *          required=true,
+     *          type="integer",
+     *          in="path"
+     *      ),
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @param null $group_id
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
     public function getGroups($group_id = null)
     {
 
@@ -123,83 +123,81 @@ class UserController extends Controller
     }
 
     /**
-    *
-    * @SWG\Post(
-    *      path="/users/new",
-    *      tags={"Users"},
-    *      summary="Create or update a user",
-    *      description="Creates or Updates Users and refreshTokens",
-    *      security={"ApiKeyAuth"},
-    *      @SWG\Parameter(
-    *          name="user_id",
-    *          description="Eve Online Character ID",
-    *          required=true,
-    *          in="body",
-    *          @SWG\Schema(type="integer")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="group_id",
-    *          description="Group id. If ommited a new group is created",
-    *          required=false,
-    *          in="body",
-    *          @SWG\Schema(type="integer")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="name",
-    *          description="Eve Online Character Name",
-    *          required=true,
-    *          in="body",
-    *          @SWG\Schema(type="string")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="active",
-    *          description="Seat Account Active. Default True",
-    *          required=false,
-    *          in="body",
-    *          @SWG\Schema(type="boolean")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="hash",
-    *          description="Character Owner Hash",
-    *          required=true,
-    *          in="body",
-    *          @SWG\Schema(type="string")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="refresh_token",
-    *          description="A valid Refresh Token",
-    *          required=true,
-    *          in="body",
-    *          @SWG\Schema(type="string")
-    *      ),
-    *     @SWG\Parameter(
-    *          name="scopes",
-    *          description="ESI Scopes for refreshToken. Defaults to Seat Scopes",
-    *          required=false,
-    *          in="body",
-    *          @SWG\Schema(type="json")
-    *      ),
-    *      @SWG\Response(response=200, description="Successful operation"),
-    *      @SWG\Response(response=400, description="Bad request"),
-    *      @SWG\Response(response=401, description="Unauthorized"),
-    *     )
-    *
-    * @param null $user_id
-    *
-    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-    */
-
+     * @SWG\Post(
+     *      path="/users/new",
+     *      tags={"Users"},
+     *      summary="Create or update a user",
+     *      description="Creates or Updates Users and refreshTokens",
+     *      security={"ApiKeyAuth"},
+     *      @SWG\Parameter(
+     *          name="user_id",
+     *          description="Eve Online Character ID",
+     *          required=true,
+     *          in="body",
+     *          @SWG\Schema(type="integer")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="group_id",
+     *          description="Group id. If ommited a new group is created",
+     *          required=false,
+     *          in="body",
+     *          @SWG\Schema(type="integer")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="name",
+     *          description="Eve Online Character Name",
+     *          required=true,
+     *          in="body",
+     *          @SWG\Schema(type="string")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="active",
+     *          description="Seat Account Active. Default True",
+     *          required=false,
+     *          in="body",
+     *          @SWG\Schema(type="boolean")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="hash",
+     *          description="Character Owner Hash",
+     *          required=true,
+     *          in="body",
+     *          @SWG\Schema(type="string")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="refresh_token",
+     *          description="A valid Refresh Token",
+     *          required=true,
+     *          in="body",
+     *          @SWG\Schema(type="string")
+     *      ),
+     *     @SWG\Parameter(
+     *          name="scopes",
+     *          description="ESI Scopes for refreshToken. Defaults to Seat Scopes",
+     *          required=false,
+     *          in="body",
+     *          @SWG\Schema(type="json")
+     *      ),
+     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=400, description="Bad request"),
+     *      @SWG\Response(response=401, description="Unauthorized"),
+     *     )
+     *
+     * @param null $user_id
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
     public function postNew(Request $request)
     {
-        
-        $id         = $request->input('id');
-        $group_id   = $request->input('group_id');
-        $name       = $request->input('name');
-        $active     = $request->input('active');
-        $hash       = $request->input('hash');
-        $new        = false;
-                            
-        if (is_null($user=User::find($id))){
+
+        $id = $request->input('id');
+        $group_id = $request->input('group_id');
+        $name = $request->input('name');
+        $active = $request->input('active');
+        $hash = $request->input('hash');
+        $new = false;
+
+        if (is_null($user = User::find($id))){
             $user = User::forceCreate([  // id is not fillable
                 'id'                   => $id,
                 'group_id'             => is_null($group_id) ? Group::create()->id : $group_id,
@@ -210,27 +208,25 @@ class UserController extends Controller
             $new = true;
         }
         else{
-            $user->group_id             = is_null($group_id) ? Group::create()->id : $group_id;
-            $user->name                 = $name;
-            $user->active               = true;
+            $user->group_id = is_null($group_id) ? Group::create()->id : $group_id;
+            $user->name = $name;
+            $user->active = true;
             $user->character_owner_hash = $hash;
             $user->save();
-        };
+        }
 
-
-        $character_id   = $request->input('id');
-        $refresh_token  = $request->input('refresh_token');
-        $scopes         = $request->input('scopes');
-        $expires_on     = '1980-01-01 00:00:00';
-        $token          = '-';
-
+        $character_id = $request->input('id');
+        $refresh_token = $request->input('refresh_token');
+        $scopes = $request->input('scopes');
+        $expires_on = '1980-01-01 00:00:00';
+        $token = '-';
 
         $userRefreshToken = RefreshToken::firstorCreate(
             ['character_id' => $character_id],
             ['refresh_token'=> $refresh_token,
                 'scopes'=> is_null($scopes) ? setting('sso_scopes', true) : $scopes,
                 'expires_on'=>$expires_on,
-                'token'=>$token]
+                'token'=>$token, ]
         );
 
         return response()->json(['OK'=>true, 'new'=>$new, 'group_id'=>$user->group_id, 'scopes'=>$userRefreshToken->scopes]);

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -31,45 +31,45 @@ use Seat\Web\Models\Group;
 use Seat\Web\Models\User;
 
 /**
- * Class UserController.
- * @package Seat\Api\Http\Controllers\Api\v2
- */
+* Class UserController.
+* @package Seat\Api\Http\Controllers\Api\v2
+*/
 class UserController extends Controller
 {
     /**
-     * @SWG\Get(
-     *      path="/users",
-     *      tags={"Users"},
-     *      summary="Get a list of users, associated character id's and group ids",
-     *      description="Returns list of users",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @SWG\Get(
-     *      path="/users/{user_id}",
-     *      tags={"Users"},
-     *      summary="Get group id's and assosciated character_id's for a user",
-     *      description="Returns a user",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Parameter(
-     *          name="user_id",
-     *          description="User id",
-     *          required=true,
-     *          type="integer",
-     *          in="path"
-     *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @param null $user_id
-     *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-     */
+    * @SWG\Get(
+    *      path="/users",
+    *      tags={"Users"},
+    *      summary="Get a list of users, associated character id's and group ids",
+    *      description="Returns list of users",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @SWG\Get(
+    *      path="/users/{user_id}",
+    *      tags={"Users"},
+    *      summary="Get group id's and assosciated character_id's for a user",
+    *      description="Returns a user",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Parameter(
+    *          name="user_id",
+    *          description="User id",
+    *          required=true,
+    *          type="integer",
+    *          in="path"
+    *      ),
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @param null $user_id
+    *
+    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    */
     public function getUsers($user_id = null)
     {
 
@@ -80,39 +80,39 @@ class UserController extends Controller
     }
 
     /**
-     * @SWG\Get(
-     *      path="/users/groups",
-     *      tags={"Users"},
-     *      summary="Get a list of groups with their associated character_id's",
-     *      description="Returns list of groups",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @SWG\Get(
-     *      path="/users/groups/{group_id}",
-     *      tags={"Users"},
-     *      summary="Get a group with its associated character_id's",
-     *      description="Returns a group",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Parameter(
-     *          name="group_id",
-     *          description="Group id",
-     *          required=true,
-     *          type="integer",
-     *          in="path"
-     *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @param null $group_id
-     *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-     */
+    * @SWG\Get(
+    *      path="/users/groups",
+    *      tags={"Users"},
+    *      summary="Get a list of groups with their associated character_id's",
+    *      description="Returns list of groups",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @SWG\Get(
+    *      path="/users/groups/{group_id}",
+    *      tags={"Users"},
+    *      summary="Get a group with its associated character_id's",
+    *      description="Returns a group",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Parameter(
+    *          name="group_id",
+    *          description="Group id",
+    *          required=true,
+    *          type="integer",
+    *          in="path"
+    *      ),
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @param null $group_id
+    *
+    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    */
     public function getGroups($group_id = null)
     {
 
@@ -123,74 +123,74 @@ class UserController extends Controller
     }
 
     /**
-     * @SWG\Post(
-     *      path="/users/new",
-     *      tags={"Users"},
-     *      summary="Create or update a user",
-     *      description="Creates or Updates Users and refreshTokens",
-     *      security={"ApiKeyAuth"},
-     *      @SWG\Parameter(
-     *          name="user_id",
-     *          description="Eve Online Character ID",
-     *          required=true,
-     *          in="body",
-     *          @SWG\Schema(type="integer")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="group_id",
-     *          description="Group id. If ommited a new group is created",
-     *          required=false,
-     *          in="body",
-     *          @SWG\Schema(type="integer")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="name",
-     *          description="Eve Online Character Name",
-     *          required=true,
-     *          in="body",
-     *          @SWG\Schema(type="string")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="active",
-     *          description="Seat Account Active. Default True",
-     *          required=false,
-     *          in="body",
-     *          @SWG\Schema(type="boolean")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="hash",
-     *          description="Character Owner Hash",
-     *          required=true,
-     *          in="body",
-     *          @SWG\Schema(type="string")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="refresh_token",
-     *          description="A valid Refresh Token",
-     *          required=true,
-     *          in="body",
-     *          @SWG\Schema(type="string")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="scopes",
-     *          description="ESI Scopes for refreshToken. Defaults to Seat Scopes",
-     *          required=false,
-     *          in="body",
-     *          @SWG\Schema(type="json")
-     *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
-     *      @SWG\Response(response=400, description="Bad request"),
-     *      @SWG\Response(response=401, description="Unauthorized"),
-     *     )
-     *
-     * @param null $user_id
-     *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
-     */
+    * @SWG\Post(
+    *      path="/users/new",
+    *      tags={"Users"},
+    *      summary="Create or update a user",
+    *      description="Creates or Updates Users and refreshTokens",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Parameter(
+    *          name="user_id",
+    *          description="Eve Online Character ID",
+    *          required=true,
+    *          in="body",
+    *          @SWG\Schema(type="integer")
+    *      ),
+    *     @SWG\Parameter(
+    *          name="group_id",
+    *          description="Group id. If ommited a new group is created",
+    *          required=false,
+    *          in="body",
+    *          @SWG\Schema(type="integer")
+    *      ),
+    *     @SWG\Parameter(
+    *          name="name",
+    *          description="Eve Online Character Name",
+    *          required=true,
+    *          in="body",
+    *          @SWG\Schema(type="string")
+    *      ),
+    *     @SWG\Parameter(
+    *          name="active",
+    *          description="Seat Account Active. Default True",
+    *          required=false,
+    *          in="body",
+    *          @SWG\Schema(type="boolean")
+    *      ),
+    *     @SWG\Parameter(
+    *          name="hash",
+    *          description="Character Owner Hash",
+    *          required=true,
+    *          in="body",
+    *          @SWG\Schema(type="string")
+    *      ),
+    *     @SWG\Parameter(
+    *          name="refresh_token",
+    *          description="A valid Refresh Token",
+    *          required=true,
+    *          in="body",
+    *          @SWG\Schema(type="string")
+    *      ),
+    *     @SWG\Parameter(
+    *          name="scopes",
+    *          description="ESI Scopes for refreshToken. Defaults to Seat Scopes",
+    *          required=false,
+    *          in="body",
+    *          @SWG\Schema(type="json")
+    *      ),
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @param null $user_id
+    *
+    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    */
     public function postNew(Request $request)
     {
 
-        $id = $request->input('id');
+        $id = $request->input('user_id');
         $group_id = $request->input('group_id');
         $name = $request->input('name');
         $active = $request->input('active');
@@ -231,4 +231,73 @@ class UserController extends Controller
 
         return response()->json(['OK'=>true, 'new'=>$new, 'group_id'=>$user->group_id, 'scopes'=>$userRefreshToken->scopes]);
     }
+
+    /**
+    * @SWG\Post(
+    *      path="/users/enable/{user_id}",
+    *      tags={"Users"},
+    *      summary="Enable a user",
+    *      description="Enables a User Account",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Parameter(
+    *          name="user_id",
+    *          description="Eve Online Character ID",
+    *          required=true,
+    *          in="path",
+    *          type="integer"
+    *      ),
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @param null $user_id
+    *
+    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    */
+
+    public function postEnable($user_id=null){
+        
+        $user = User::find($user_id);
+        if (is_null($user)) return response()->json(['OK'=>false]);
+        $user->active = true;
+        $user->save();
+        return response()->json(['OK'=>true]);
+
+    }
+
+    /**
+    * @SWG\Post(
+    *      path="/users/disable/{user_id}",
+    *      tags={"Users"},
+    *      summary="Disable User",
+    *      description="Disables a User Account",
+    *      security={"ApiKeyAuth"},
+    *      @SWG\Parameter(
+    *          name="user_id",
+    *          description="Eve Online Character ID",
+    *          required=true,
+    *          in="path",
+    *          type="integer"
+    *      ),
+    *      @SWG\Response(response=200, description="Successful operation"),
+    *      @SWG\Response(response=400, description="Bad request"),
+    *      @SWG\Response(response=401, description="Unauthorized"),
+    *     )
+    *
+    * @param null $user_id
+    *
+    * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    */
+
+    public function postDisable($user_id=null){
+
+        $user = User::find($user_id);
+        if (is_null($user)) return response()->json(['OK'=>false]);
+        $user->active = false;
+        $user->save();
+        return response()->json(['OK'=>true]);
+
+    }
+
 }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -56,7 +56,7 @@ Route::group([
         'prefix'     => 'api',
     ], function () {
 
-        // The version 2 API :D 
+        // The version 2 API :D
         Route::group(['namespace' => 'v2', 'prefix' => 'v2'], function () {
 
             Route::group(['prefix' => 'users'], function () {

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,130 +1,132 @@
 <?php
 
 /*
- * This file is part of SeAT
- *
- * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
+* This file is part of SeAT
+*
+* Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program; if not, write to the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 
 Route::group([
     'namespace' => 'Seat\Api\Http\Controllers',
-], function () {
-
-    Route::group(['middleware' => 'web'], function () {
-
-        // Http Routes to the API Key Administration Section
-        Route::group([
-            'namespace'  => 'Admin',
-            'middleware' => ['auth', 'bouncer:superuser'],
-            'prefix'     => 'api-admin',
-        ], function () {
-
-            Route::get('/', [
-                'as'   => 'api-admin.list',
-                'uses' => 'ApiAdminController@listTokens', ]);
-            Route::post('/', [
-                'as'   => 'api-admin.token.create',
-                'uses' => 'ApiAdminController@generateToken', ]);
-            Route::get('/logs/{token_id}', [
-                'as'   => 'api-admin.token.logs',
-                'uses' => 'ApiAdminController@showLogs', ]);
-            Route::get('/delete/{token_id}', [
-                'as'   => 'api-admin.token.delete',
-                'uses' => 'ApiAdminController@deleteToken', ]);
-
-        });
-    });
-
-    // Http Routes to the SeAT API itself
-    Route::group([
-        'namespace'  => 'Api',
-        'middleware' => 'api.auth',
-        'prefix'     => 'api',
     ], function () {
 
-        // The version 2 API :D
-        Route::group(['namespace' => 'v2', 'prefix' => 'v2'], function () {
+        Route::group(['middleware' => 'web'], function () {
 
-            Route::group(['prefix' => 'users'], function () {
+            // Http Routes to the API Key Administration Section
+            Route::group([
+                'namespace'  => 'Admin',
+                'middleware' => ['auth', 'bouncer:superuser'],
+                'prefix'     => 'api-admin',
+                ], function () {
 
-                Route::get('/{user_id?}', 'UserController@getUsers')->where(['user_id' => '[0-9]+']);
-                Route::get('/groups/{group_id?}', 'UserController@getGroups');
-                Route::post('/new', 'UserController@postNew');
-            });
+                    Route::get('/', [
+                        'as'   => 'api-admin.list',
+                        'uses' => 'ApiAdminController@listTokens', ]);
+                    Route::post('/', [
+                        'as'   => 'api-admin.token.create',
+                        'uses' => 'ApiAdminController@generateToken', ]);
+                    Route::get('/logs/{token_id}', [
+                        'as'   => 'api-admin.token.logs',
+                        'uses' => 'ApiAdminController@showLogs', ]);
+                    Route::get('/delete/{token_id}', [
+                        'as'   => 'api-admin.token.delete',
+                        'uses' => 'ApiAdminController@deleteToken', ]);
 
-            Route::group(['prefix' => 'roles'], function () {
-
-                Route::get('/', 'RoleController@getIndex');
-                Route::get('/detail/{role_id}', 'RoleController@getDetail');
-                Route::post('/new', 'RoleController@postNew');
-                Route::delete('/delete/{role_id}', 'RoleController@deleteRole');
-                Route::get('/grant-user-role/{user_id}/{role_id}', 'RoleController@getGrantUserRole');
-                Route::get('/revoke-user-role/{user_id}/{role_id}', 'RoleController@getRevokeUserRole');
-                Route::post('/affiliation/character', 'RoleController@postAddCharacterAffiliation');
-                Route::post('/affiliation/corporation', 'RoleController@postAddCorporationAffiliation');
-
-                Route::group(['prefix' => 'query'], function () {
-
-                    Route::get('/permissions', 'RoleLookupController@getPermissions');
-                    Route::get('/role-check/{character_id}/{role_name}', 'RoleLookupController@getRoleCheck');
-                    Route::get('/permission-check/{character_id}/{permission_name}', 'RoleLookupController@getPermissionCheck');
-                });
-            });
-
-            Route::group(['prefix' => 'killmails'], function () {
-
-                Route::get('/detail/{killmail_id}', 'KillmailsController@getDetail');
-            });
-
-            Route::group(['prefix' => 'character'], function () {
-
-                Route::get('/assets/{character_id}/{item_id?}', 'CharacterController@getAssets');
-                Route::get('/bookmarks/{character_id}', 'CharacterController@getBookmarks');
-                Route::get('/contacts/{character_id}', 'CharacterController@getContacts');
-                Route::get('/industry/{character_id}', 'CharacterController@getIndustry');
-                Route::get('/killmails/{character_id}/{killmail_id?}', 'CharacterController@getKillmails');
-                Route::get('/market-orders/{character_id}', 'CharacterController@getMarketOrders');
-                Route::get('/contracts/{character_id}', 'CharacterController@getContracts');
-                Route::get('/sheet/{character_id}', 'CharacterController@getSheet');
-                Route::get('/skills/{character_id}', 'CharacterController@getSkills');
-                Route::get('/skill-queue/{character_id}', 'CharacterController@getSkillQueue');
-                Route::get('/wallet-journal/{character_id}', 'CharacterController@getWalletJournal');
-                Route::get('/wallet-transactions/{character_id}', 'CharacterController@getWalletTransactions');
-                Route::get('/corporation-history/{character_id}', 'CharacterController@getCorporationHistory');
-                Route::get('/jump-clones/{character_id}', 'CharacterController@getJumpClones');
-                Route::get('/mail/{character_id}', 'CharacterController@getMail');
-                Route::get('/notifications/{character_id}', 'CharacterController@getNotifications');
-            });
-
-            Route::group(['prefix' => 'corporation'], function () {
-
-                Route::get('/assets/{corporation_id}', 'CorporationController@getAssets');
-                Route::get('/bookmarks/{corporation_id}', 'CorporationController@getBookmarks');
-                Route::get('/contacts/{corporation_id}', 'CorporationController@getContacts');
-                Route::get('/contracts/{corporation_id}', 'CorporationController@getContracts');
-                Route::get('/industry/{corporation_id}', 'CorporationController@getIndustry');
-                Route::get('/killmails/{corporation_id}', 'CorporationController@getKillmails');
-                Route::get('/market-orders/{corporation_id}', 'CorporationController@getMarketOrders');
-                Route::get('/member-tracking/{corporation_id}', 'CorporationController@getMemberTracking');
-                Route::get('/sheet/{corporation_id}', 'CorporationController@getSheet');
-                Route::get('/wallet-journal/{corporation_id}', 'CorporationController@getWalletJournal');
-                Route::get('/wallet-transactions/{corporation_id}', 'CorporationController@getWalletTransactions');
             });
         });
 
-    });
+        // Http Routes to the SeAT API itself
+        Route::group([
+            'namespace'  => 'Api',
+            'middleware' => 'api.auth',
+            'prefix'     => 'api',
+            ], function () {
+
+                // The version 2 API :D
+                Route::group(['namespace' => 'v2', 'prefix' => 'v2'], function () {
+
+                    Route::group(['prefix' => 'users'], function () {
+
+                        Route::get('/{user_id?}', 'UserController@getUsers')->where(['user_id' => '[0-9]+']);
+                        Route::get('/groups/{group_id?}', 'UserController@getGroups');
+                        Route::post('/new', 'UserController@postNew');
+                        Route::post('/enable/{user_id?}', 'UserController@postEnable')->where(['user_id' => '[0-9]+']);
+                        Route::post('/disable/{user_id?}', 'UserController@postDisable')->where(['user_id' => '[0-9]+']);
+                    });
+
+                    Route::group(['prefix' => 'roles'], function () {
+
+                        Route::get('/', 'RoleController@getIndex');
+                        Route::get('/detail/{role_id}', 'RoleController@getDetail');
+                        Route::post('/new', 'RoleController@postNew');
+                        Route::delete('/delete/{role_id}', 'RoleController@deleteRole');
+                        Route::get('/grant-user-role/{user_id}/{role_id}', 'RoleController@getGrantUserRole');
+                        Route::get('/revoke-user-role/{user_id}/{role_id}', 'RoleController@getRevokeUserRole');
+                        Route::post('/affiliation/character', 'RoleController@postAddCharacterAffiliation');
+                        Route::post('/affiliation/corporation', 'RoleController@postAddCorporationAffiliation');
+
+                        Route::group(['prefix' => 'query'], function () {
+
+                            Route::get('/permissions', 'RoleLookupController@getPermissions');
+                            Route::get('/role-check/{character_id}/{role_name}', 'RoleLookupController@getRoleCheck');
+                            Route::get('/permission-check/{character_id}/{permission_name}', 'RoleLookupController@getPermissionCheck');
+                        });
+                    });
+
+                    Route::group(['prefix' => 'killmails'], function () {
+
+                        Route::get('/detail/{killmail_id}', 'KillmailsController@getDetail');
+                    });
+
+                    Route::group(['prefix' => 'character'], function () {
+
+                        Route::get('/assets/{character_id}/{item_id?}', 'CharacterController@getAssets');
+                        Route::get('/bookmarks/{character_id}', 'CharacterController@getBookmarks');
+                        Route::get('/contacts/{character_id}', 'CharacterController@getContacts');
+                        Route::get('/industry/{character_id}', 'CharacterController@getIndustry');
+                        Route::get('/killmails/{character_id}/{killmail_id?}', 'CharacterController@getKillmails');
+                        Route::get('/market-orders/{character_id}', 'CharacterController@getMarketOrders');
+                        Route::get('/contracts/{character_id}', 'CharacterController@getContracts');
+                        Route::get('/sheet/{character_id}', 'CharacterController@getSheet');
+                        Route::get('/skills/{character_id}', 'CharacterController@getSkills');
+                        Route::get('/skill-queue/{character_id}', 'CharacterController@getSkillQueue');
+                        Route::get('/wallet-journal/{character_id}', 'CharacterController@getWalletJournal');
+                        Route::get('/wallet-transactions/{character_id}', 'CharacterController@getWalletTransactions');
+                        Route::get('/corporation-history/{character_id}', 'CharacterController@getCorporationHistory');
+                        Route::get('/jump-clones/{character_id}', 'CharacterController@getJumpClones');
+                        Route::get('/mail/{character_id}', 'CharacterController@getMail');
+                        Route::get('/notifications/{character_id}', 'CharacterController@getNotifications');
+                    });
+
+                    Route::group(['prefix' => 'corporation'], function () {
+
+                        Route::get('/assets/{corporation_id}', 'CorporationController@getAssets');
+                        Route::get('/bookmarks/{corporation_id}', 'CorporationController@getBookmarks');
+                        Route::get('/contacts/{corporation_id}', 'CorporationController@getContacts');
+                        Route::get('/contracts/{corporation_id}', 'CorporationController@getContracts');
+                        Route::get('/industry/{corporation_id}', 'CorporationController@getIndustry');
+                        Route::get('/killmails/{corporation_id}', 'CorporationController@getKillmails');
+                        Route::get('/market-orders/{corporation_id}', 'CorporationController@getMarketOrders');
+                        Route::get('/member-tracking/{corporation_id}', 'CorporationController@getMemberTracking');
+                        Route::get('/sheet/{corporation_id}', 'CorporationController@getSheet');
+                        Route::get('/wallet-journal/{corporation_id}', 'CorporationController@getWalletJournal');
+                        Route::get('/wallet-transactions/{corporation_id}', 'CorporationController@getWalletTransactions');
+                    });
+                });
+
+        });
 });

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -56,13 +56,14 @@ Route::group([
         'prefix'     => 'api',
     ], function () {
 
-        // The version 2 API :D
+        // The version 2 API :D 
         Route::group(['namespace' => 'v2', 'prefix' => 'v2'], function () {
 
             Route::group(['prefix' => 'users'], function () {
 
                 Route::get('/{user_id?}', 'UserController@getUsers')->where(['user_id' => '[0-9]+']);
                 Route::get('/groups/{group_id?}', 'UserController@getGroups');
+                Route::post('/new', 'UserController@postNew');
             });
 
             Route::group(['prefix' => 'roles'], function () {


### PR DESCRIPTION
This is the final part of possible changes for allowing the use of an External Auth system to create users and ESI keys from a 3rd party auth system.

- Added users/new to create a new user with refreshToken 
- Added users/enable/{user_id} to enable a user
- Added users/disable/{user_id} to disable a user.

This PR also requires PRs  eveseat/seat 343 and  eveseat/web 172 changes to support using separate client_id / secret_key pairs for logging in to SEATand Fetching Data via the ESI