### PR TITLE
Improve api docs

### DIFF
--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -65,7 +65,19 @@ class ApiServiceProvider extends ServiceProvider
 
         // Tell L5-swagger where to find annotations. These form
         // part of the controllers themselves.
-        config(['l5-swagger.paths.annotations' => __DIR__ . '/Http/Controllers/Api/v2']);
+
+        // ensure current annotations setting is an array of path or transform into it
+        $current_annotations = config('l5-swagger.paths.annotations');
+        if (! is_array($current_annotations))
+            $current_annotations = [$current_annotations];
+
+        // merge paths together and update config
+        config([
+            'l5-swagger.paths.annotations' => array_unique(array_merge($current_annotations, [
+                __DIR__ . '/Http/Controllers/Api/v2',
+            ])),
+        ]);
+
         config(['l5-swagger.swagger_version' => '3.0']);
 
         // Use base host configured in the .env file for the swagger host.

--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -320,7 +320,16 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterCorporationHistory")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -459,7 +468,16 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterJumpClone")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -519,7 +537,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/MailHeader")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -531,7 +628,8 @@ class CharacterController extends ApiController
     public function getMail(int $character_id)
     {
 
-        return MailResource::collection(MailHeader::where('character_id', $character_id)->paginate());
+        return MailResource::collection(
+            MailHeader::with('body', 'recipients')->where('character_id', $character_id)->paginate());
     }
 
     /**
@@ -657,7 +755,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterNotification")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -687,7 +864,16 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="data",
+     *                  ref="#/definitions/CharacterInfo"
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -699,7 +885,7 @@ class CharacterController extends ApiController
     public function getSheet(int $character_id)
     {
 
-        return new CharacterSheetResource(CharacterInfo::findOrFail($character_id));
+        return new CharacterSheetResource(CharacterInfo::with('balance')->findOrFail($character_id));
     }
 
     /**
@@ -716,7 +902,16 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterSkill")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -728,7 +923,8 @@ class CharacterController extends ApiController
     public function getSkills(int $character_id)
     {
 
-        return SkillsResource::collection(CharacterSkill::where('character_id', $character_id)->get());
+        return SkillsResource::collection(
+            CharacterSkill::with('type')->where('character_id', $character_id)->get());
     }
 
     /**
@@ -745,7 +941,16 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterSkillQueue")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -757,7 +962,8 @@ class CharacterController extends ApiController
     public function getSkillQueue(int $character_id)
     {
 
-        return SkillQueueResource::collection(CharacterSkillQueue::where('character_id', $character_id)->get());
+        return SkillQueueResource::collection(
+            CharacterSkillQueue::with('type')->where('character_id', $character_id)->get());
     }
 
     /**

--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -23,6 +23,7 @@
 namespace Seat\Api\Http\Controllers\Api\v2;
 
 use Seat\Api\Http\Resources\AssetResource;
+use Seat\Api\Http\Resources\BookmarkResource;
 use Seat\Api\Http\Resources\CharacterSheetResource;
 use Seat\Api\Http\Resources\ContactResource;
 use Seat\Api\Http\Resources\ContractResource;
@@ -38,6 +39,7 @@ use Seat\Api\Http\Resources\SkillsResource;
 use Seat\Api\Http\Resources\WalletJournalResource;
 use Seat\Api\Http\Resources\WalletTransactionResource;
 use Seat\Eveapi\Models\Assets\CharacterAsset;
+use Seat\Eveapi\Models\Bookmarks\CharacterBookmark;
 use Seat\Eveapi\Models\Character\CharacterCorporationHistory;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Character\CharacterNotification;
@@ -134,17 +136,26 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterBookmark")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
      *
      * @param int $chacter_id
      */
-    public function getBookmarks(int $chacter_id)
+    public function getBookmarks(int $character_id)
     {
 
-        // TODO
+        return BookmarkResource::collection(CharacterBookmark::where('character_id', $character_id)->get());
     }
 
     /**
@@ -161,7 +172,16 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterContact")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -191,7 +211,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterContract")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -548,7 +548,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterOrder")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -350,7 +350,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterIndustryJob")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -774,7 +774,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterWalletJournal")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -804,7 +883,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterWalletTransaction")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -816,7 +974,9 @@ class CharacterController extends ApiController
     public function getWalletTransactions(int $character_id)
     {
 
-        return WalletTransactionResource::collection(CharacterWalletTransaction::where('character_id', $character_id)
+        return WalletTransactionResource::collection(
+                CharacterWalletTransaction::with('type')
+                    ->where('character_id', $character_id)
             ->paginate());
     }
 }

--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -507,7 +507,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterKillmail")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -76,7 +76,86 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CharacterAsset")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -101,7 +180,16 @@ class CharacterController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="data",
+     *                  ref="#/definitions/CharacterAsset"
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -604,7 +604,86 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationWalletJournal")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -634,7 +713,86 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationWalletTransaction")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -646,7 +804,9 @@ class CorporationController extends ApiController
     public function getWalletTransactions(int $corporation_id)
     {
 
-        return WalletTransactionResource::collection(CorporationWalletTransaction::where('corporation_id', $corporation_id)
+        return WalletTransactionResource::collection(
+                CorporationWalletTransaction::with('type')
+                    ->where('corporation_id', $corporation_id)
             ->paginate());
     }
 }

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -274,7 +274,15 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="data",
+     *                  ref="#definitions/CorporationMemberTracking"
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -304,7 +312,15 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="data",
+     *                  ref="#definitions/CorporationInfo"
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -420,7 +420,86 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationOrder")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -65,7 +65,86 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationAsset")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -95,7 +95,16 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationBookmark")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -124,7 +133,16 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationContact")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -154,7 +172,86 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationContract")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -390,7 +390,86 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationKillmail")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -281,7 +281,86 @@ class CorporationController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/CorporationIndustryJob")
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="links",
+     *                  description="Provide pagination urls for navigation",
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="first",
+     *                      description="First page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="last",
+     *                      description="Last page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="prev",
+     *                      description="Previous page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="next",
+     *                      description="Next page"
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="meta",
+     *                  description="Information related to the paginated response",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="current_page",
+     *                      description="The current page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="from",
+     *                      description="The first entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="last_page",
+     *                      description="The last page available"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      format="uri",
+     *                      property="path",
+     *                      description="The base endpoint"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="per_page",
+     *                      description="The pagination step"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="to",
+     *                      description="The last entity number on the page"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      property="total",
+     *                      description="The total of available entities"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/KillmailsController.php
+++ b/src/Http/Controllers/Api/v2/KillmailsController.php
@@ -33,7 +33,7 @@ class KillmailsController extends ApiController
 {
     /**
      * @SWG\Get(
-     *      path="/killmails/detail/{killmail_id}",
+     *      path="/killmails/{killmail_id}",
      *      tags={"Killmails"},
      *      summary="Get full details about a killmail",
      *      description="Returns a detailed killmail",
@@ -45,7 +45,16 @@ class KillmailsController extends ApiController
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="data",
+     *                  ref="#/definitions/KillmailDetail"
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -61,6 +70,6 @@ class KillmailsController extends ApiController
     public function getDetail(int $killmail_id)
     {
 
-        return new KillmailDetailResource(KillmailDetail::findOrFail($killmail_id));
+        return new KillmailDetailResource(KillmailDetail::with('attackers', 'victims')->findOrFail($killmail_id));
     }
 }

--- a/src/Http/Controllers/Api/v2/RoleController.php
+++ b/src/Http/Controllers/Api/v2/RoleController.php
@@ -44,7 +44,27 @@ class RoleController extends Controller
      *      summary="Get the roles configured within SeAT",
      *      description="Returns a list of roles",
      *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="array",
+     *              description="Array of defined roles",
+     *              @SWG\Items(
+     *                  type="object",
+     *                  description="Role",
+     *                  @SWG\Property(
+     *                      type="integer",
+     *                      minimum=1,
+     *                      property="id",
+     *                      description="The unique identifier of the role"
+     *                  ),
+     *                  @SWG\Property(
+     *                      type="string",
+     *                      property="title",
+     *                      description="The name of the role"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -61,7 +81,7 @@ class RoleController extends Controller
 
     /**
      * @SWG\Get(
-     *      path="/roles/detail/{role_id}",
+     *      path="/roles/{role_id}",
      *      tags={"Roles"},
      *      summary="Get detailed information about a role",
      *      description="Returns a roles details",
@@ -73,7 +93,158 @@ class RoleController extends Controller
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              description="Role",
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=1,
+     *                  property="id",
+     *                  description="The unique identifier of the role"
+     *              ),
+     *              @SWG\Property(
+     *                  type="string",
+     *                  property="title",
+     *                  description="The name of the role"
+     *              ),
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="groups",
+     *                  description="Attached user relationships",
+     *                  @SWG\Items(
+     *                      type="object",
+     *                      description="User relationship",
+     *                      @SWG\Property(
+     *                          type="integer",
+     *                          minimum=1,
+     *                          property="id",
+     *                          description="The unique identifier of the relationship"
+     *                      ),
+     *                      @SWG\Property(
+     *                          type="string",
+     *                          format="date-time",
+     *                          property="created_at",
+     *                          description="The creation date-time of the relationship"
+     *                      ),
+     *                      @SWG\Property(
+     *                          type="string",
+     *                          format="date-time",
+     *                          property="updated_at",
+     *                          description="The last update date-time of the relationship"
+     *                      ),
+     *                      @SWG\Property(
+     *                          type="object",
+     *                          property="pivot",
+     *                          description="The association keys between user relationship and role",
+     *                          @SWG\Property(
+     *                              type="integer",
+     *                              minimum=1,
+     *                              property="role_id",
+     *                              description="The role identifier"
+     *                          ),
+     *                          @SWG\Property(
+     *                              type="integer",
+     *                              minimum=1,
+     *                              property="group_id",
+     *                              description="The user relationship identifier"
+     *                          )
+     *                      )
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="permissions",
+     *                  description="A list of permissions object",
+     *                  @SWG\Items(
+     *                      type="object",
+     *                      description="Permission",
+     *                      @SWG\Property(
+     *                          type="integer",
+     *                          minimum=1,
+     *                          property="id",
+     *                          description="The unique identifier of permission"
+     *                      ),
+     *                      @SWG\Property(
+     *                          type="string",
+     *                          property="title",
+     *                          description="The permission name"
+     *                      ),
+     *                      @SWG\Property(
+     *                          type="object",
+     *                          property="pivot",
+     *                          description="The association keys between the role and permission",
+     *                          @SWG\Property(
+     *                              type="integer",
+     *                              minimum=1,
+     *                              property="role_id",
+     *                              description="The role identifier"
+     *                          ),
+     *                          @SWG\Property(
+     *                              type="integer",
+     *                              minimum=1,
+     *                              property="permission_id",
+     *                              description="The permission identifier"
+     *                          ),
+     *                          @SWG\Property(
+     *                              type="boolean",
+     *                              property="not",
+     *                              description="True if the permission is negated - meaning role does not have it"
+     *                          )
+     *                      )
+     *                  )
+     *              ),
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="affiliations",
+     *                  description="A list of affiliated entities (character or corporation)",
+     *                  @SWG\Items(
+     *                      type="object",
+     *                      description="Affiliation",
+     *                      @SWG\Property(
+     *                          type="integer",
+     *                          minimum=1,
+     *                          property="id",
+     *                          description="The affiliation identifier"
+     *                      ),
+     *                      @SWG\Property(
+     *                          type="integer",
+     *                          format="int64",
+     *                          minimum=0,
+     *                          property="affiliation",
+     *                          description="The entity ID to which affiliation is related (0 if all)"
+     *                      ),
+     *                      @SWG\Property(
+     *                          type="string",
+     *                          enum={"corp", "char"},
+     *                          property="type",
+     *                          description="Determine the type of entity - char for Character - corp for Corporation"
+     *                      ),
+     *                      @SWG\Property(
+     *                          type="object",
+     *                          property="pivot",
+     *                          description="The association keys between the role and an entity",
+     *                          @SWG\Property(
+     *                              type="integer",
+     *                              property="role_id",
+     *                              description="The role identifier"
+     *                          ),
+     *                          @SWG\Property(
+     *                              type="integer",
+     *                              format="int64",
+     *                              property="affiliation_id",
+     *                              description="The affiliated entity identifier"
+     *                          ),
+     *                          @SWG\Property(
+     *                              type="boolean",
+     *                              property="not",
+     *                              description="Determine if the affiliation is negated (meaning excluded)"
+     *                          )
+     *                      )
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -85,7 +256,7 @@ class RoleController extends Controller
     public function getDetail($role_id)
     {
 
-        $role = Role::with('users', 'permissions', 'affiliations')
+        $role = Role::with('groups', 'permissions', 'affiliations')
             ->where(is_numeric($role_id) ? 'id' : 'title', $role_id)
             ->first();
 
@@ -94,22 +265,62 @@ class RoleController extends Controller
 
     /**
      * @SWG\Post(
-     *      path="/roles/new",
+     *      path="/roles",
      *      tags={"Roles"},
      *      summary="Create a new SeAT role",
      *      description="Creates a role",
      *      security={"ApiKeyAuth"},
      *      @SWG\Parameter(
-     *          name="name",
-     *          description="A role name",
-     *          required=true,
-     *          type="string",
+     *          type="object",
+     *          name="body",
      *          in="body",
-     *          @SWG\Schema(type="string")
+     *          required=true,
+     *          @SWG\Schema(
+     *              required={"title"},
+     *              @SWG\Property(
+     *                  type="string",
+     *                  property="title",
+     *                  description="The new group name"
+     *              )
+     *          )
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=1,
+     *                  property="role_id",
+     *                  description="The newly created role identifier"
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
+     *      @SWG\Response(response=422, description="Unprocessable Entity",
+     *          @SWG\Schema(
+     *              type="object",
+     *              @SWG\Property(
+     *                  type="string",
+     *                  property="message",
+     *                  description="The readable error message"
+     *              ),
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="errors",
+     *                  description="Detailed information related to the encountered error",
+     *                  @SWG\Property(
+     *                      type="array",
+     *                      property="title",
+     *                      description="The field for which the error has been encountered",
+     *                      @SWG\Items(
+     *                          type="string",
+     *                          description="A list of the encountered error for this field"
+     *                      )
+     *                  )
+     *              )
+     *          )
+     *      ),
      *     )
      *
      * @param \Illuminate\Http\Request $request
@@ -119,7 +330,11 @@ class RoleController extends Controller
     public function postNew(Request $request)
     {
 
-        $name = $request->input('name');
+        $this->validate($request, [
+            'title' => 'required|string|unique:roles,title',
+        ]);
+
+        $name = $request->input('title');
 
         $role = $this->addRole($name);
 
@@ -134,28 +349,30 @@ class RoleController extends Controller
      *      description="Adds a character affiliation",
      *      security={"ApiKeyAuth"},
      *      @SWG\Parameter(
-     *          name="role_id",
-     *          description="Role id",
+     *          type="object",
+     *          name="body",
+     *          in="body",
      *          required=true,
-     *          type="integer",
-     *          in="body",
-     *          @SWG\Schema(type="integer")
-     *      ),
-     *      @SWG\Parameter(
-     *          name="character_id",
-     *          description="Character id",
-     *          required=true,
-     *          type="integer",
-     *          in="body",
-     *          @SWG\Schema(type="integer")
-     *      ),
-     *      @SWG\Parameter(
-     *          name="inverse",
-     *          description="Inverse flag",
-     *          required=false,
-     *          type="boolean",
-     *          in="body",
-     *          @SWG\Schema(type="boolean")
+     *          @SWG\Schema(
+     *              required={"role_id", "character_id"},
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=1,
+     *                  property="role_id",
+     *                  description="Role id"
+     *              ),
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=0,
+     *                  property="character_id",
+     *                  description="Character id"
+     *              ),
+     *              @SWG\Property(
+     *                  type="boolean",
+     *                  property="inverse",
+     *                  description="Inverse flag"
+     *              )
+     *          )
      *      ),
      *      @SWG\Response(response=200, description="Successful operation"),
      *      @SWG\Response(response=400, description="Bad request"),
@@ -192,28 +409,30 @@ class RoleController extends Controller
      *      description="Adds a corporation affiliation",
      *      security={"ApiKeyAuth"},
      *      @SWG\Parameter(
-     *          name="role_id",
-     *          description="Role id",
+     *          type="object",
+     *          name="body",
+     *          in="body",
      *          required=true,
-     *          type="integer",
-     *          in="body",
-     *          @SWG\Schema(type="integer")
-     *      ),
-     *      @SWG\Parameter(
-     *          name="corporation_id",
-     *          description="Corporation id",
-     *          required=true,
-     *          type="integer",
-     *          in="body",
-     *          @SWG\Schema(type="integer")
-     *      ),
-     *      @SWG\Parameter(
-     *          name="inverse",
-     *          description="Inverse flag",
-     *          required=false,
-     *          type="boolean",
-     *          in="body",
-     *          @SWG\Schema(type="boolean")
+     *          @SWG\Schema(
+     *              required={"role_id", "corporation_id"},
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=1,
+     *                  property="role_id",
+     *                  description="Role id"
+     *              ),
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=0,
+     *                  property="corporation_id",
+     *                  description="Corporation id"
+     *              ),
+     *              @SWG\Property(
+     *                  type="boolean",
+     *                  property="inverse",
+     *                  description="Inverse flag"
+     *              )
+     *          )
      *      ),
      *      @SWG\Response(response=200, description="Successful operation"),
      *      @SWG\Response(response=400, description="Bad request"),
@@ -244,7 +463,7 @@ class RoleController extends Controller
 
     /**
      * @SWG\Delete(
-     *      path="/roles/delete/{role_id}",
+     *      path="/roles/{role_id}",
      *      tags={"Roles"},
      *      summary="Delete a SeAT role",
      *      description="Deletes a role",
@@ -274,55 +493,64 @@ class RoleController extends Controller
     }
 
     /**
-     * @SWG\Get(
-     *      path="/roles/grant-user-role/{user_id}/{role_id}",
+     * @SWG\Post(
+     *      path="/roles/groups",
      *      tags={"Roles"},
-     *      summary="Grant a user a SeAT role",
+     *      summary="Grant a user relationship a SeAT role",
      *      description="Grants a role",
      *      security={"ApiKeyAuth"},
      *      @SWG\Parameter(
-     *          name="user_id",
-     *          description="User id",
-     *          required=true,
-     *          type="integer",
-     *          in="path"
-     *      ),
-     *      @SWG\Parameter(
-     *          name="role_id",
-     *          description="Role id",
-     *          required=true,
-     *          type="integer",
-     *          in="path"
+     *          type="object",
+     *          name="body",
+     *          in="body",
+     *          @SWG\Schema(
+     *              required={"group_id", "role_id"},
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=1,
+     *                  property="group_id",
+     *                  description="The user relationship identifier"
+     *              ),
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=1,
+     *                  property="role_id",
+     *                  description="The role identifier"
+     *              )
+     *          )
      *      ),
      *      @SWG\Response(response=200, description="Successful operation"),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
      *
-     * @param $user_id
-     * @param $role_id
+     * @param $request
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function getGrantUserRole($user_id, $role_id)
+    public function postGrantUserRole(Request $request)
     {
+        $this->validate($request, [
+            'group_id' => 'required|exists:groups,id|numeric',
+            'role_id' => 'required|exists:roles,id|numeric',
+        ]);
 
-        $this->giveGroupRole($user_id, $role_id);
+        $this->giveGroupRole($request->input('group_id'), $request->input('role_id'));
 
         return response()->json(true);
 
     }
 
     /**
-     * @SWG\Get(
-     *      path="/roles/revoke-user-role/{user_id}/{role_id}",
+     * @SWG\Delete(
+     *      path="/roles/groups/{group_id}/{role_id}",
      *      tags={"Roles"},
-     *      summary="Revoke a SeAT role from a user",
+     *      summary="Revoke a SeAT role from a user relationship",
      *      description="Revokes a role",
      *      security={"ApiKeyAuth"},
      *      @SWG\Parameter(
-     *          name="user_id",
-     *          description="User id",
+     *          name="group_id",
+     *          description="User relationship identifier",
      *          required=true,
      *          type="integer",
      *          in="path"
@@ -344,10 +572,10 @@ class RoleController extends Controller
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function getRevokeUserRole($user_id, $role_id)
+    public function deleteRevokeGroupRole($group_id, $role_id)
     {
 
-        $this->removeUserFromRole($user_id, $role_id);
+        $this->removeGroupFromRole($group_id, $role_id);
 
         return response()->json(true);
     }

--- a/src/Http/Controllers/Api/v2/RoleLookupController.php
+++ b/src/Http/Controllers/Api/v2/RoleLookupController.php
@@ -38,7 +38,21 @@ class RoleLookupController extends Controller
      *      summary="Get the available SeAT permissions",
      *      description="Returns a list of permissions",
      *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="object",
+     *              description="Permissions list",
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="scope",
+     *                  description="Permissions for the given scope where field name is scope",
+     *                  @SWG\Items(
+     *                      type="string",
+     *                      description="Permission"
+     *                  )
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -43,7 +43,15 @@ class UserController extends Controller
      *      summary="Get a list of users, associated character id's and group ids",
      *      description="Returns list of users",
      *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#/definitions/User")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -61,7 +69,15 @@ class UserController extends Controller
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="data",
+     *                  ref="#/definitions/User"
+     *              ),
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -86,7 +102,15 @@ class UserController extends Controller
      *      summary="Get a list of groups with their associated character_id's",
      *      description="Returns list of groups",
      *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              @SWG\Property(
+     *                  type="array",
+     *                  property="data",
+     *                  @SWG\Items(ref="#definitions/Group")
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -104,7 +128,15 @@ class UserController extends Controller
      *          type="integer",
      *          in="path"
      *      ),
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              @SWG\Property(
+     *                  type="object",
+     *                  property="data",
+     *                  ref="#definitions/Group"
+     *              )
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -129,7 +161,13 @@ class UserController extends Controller
      *      summary="Get a list of the scopes configured for this instance",
      *      description="Returns list of scopes",
      *      security={"ApiKeyAuth"},
-     *      @SWG\Response(response=200, description="Successful operation"),
+     *      @SWG\Response(response=200, description="Successful operation",
+     *          @SWG\Schema(
+     *              type="array",
+     *              description="The scope list requested by the SeAT instance",
+     *              @SWG\Items(type="string")
+     *          )
+     *      ),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
      *     )
@@ -152,55 +190,51 @@ class UserController extends Controller
      *      description="Creates a new SeAT user",
      *      security={"ApiKeyAuth"},
      *      @SWG\Parameter(
-     *          name="user_id",
-     *          description="Eve Online Character ID",
+     *          type="object",
+     *          name="body",
+     *          in="body",
      *          required=true,
-     *          in="body",
-     *          @SWG\Schema(type="integer")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="group_id",
-     *          description="The SeAT group id. If ommited, a new group will be created",
-     *          required=false,
-     *          in="body",
-     *          @SWG\Schema(type="integer")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="name",
-     *          description="Eve Online Character Name",
-     *          required=true,
-     *          in="body",
-     *          @SWG\Schema(type="string")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="active",
-     *          description="Set the SeAT account state. Default is true",
-     *          required=false,
-     *          in="body",
-     *          @SWG\Schema(type="boolean")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="character_owner_hash",
-     *          description="Eve Online account character hash",
-     *          required=true,
-     *          in="body",
-     *          @SWG\Schema(type="string")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="refresh_token",
-     *          description="A refresh token for the account",
-     *          required=true,
-     *          in="body",
-     *          @SWG\Schema(type="string")
-     *      ),
-     *     @SWG\Parameter(
-     *          name="scopes",
-     *          description="ESI scopes as array that are valid for the refresh token",
-     *          required=true,
-     *          in="body",
      *          @SWG\Schema(
-     *              type="array",
-     *              @SWG\Items(type="string")
+     *              required={"user_id", "name", "character_owner_hash", "refresh_token", "scopes"},
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  format="int64",
+     *                  minimum=90000000,
+     *                  property="user_id",
+     *                  description="Eve Online Character ID"
+     *              ),
+     *              @SWG\Property(
+     *                  type="integer",
+     *                  minimum=1,
+     *                  property="group_id",
+     *                  description="The SeAT group id. If ommited, a new group will be created"
+     *              ),
+     *              @SWG\Property(
+     *                  type="string",
+     *                  property="name",
+     *                  description="Eve Online Character Name"
+     *              ),
+     *              @SWG\Property(
+     *                  type="boolean",
+     *                  property="active",
+     *                  description="Set the SeAT account state. Default is true"
+     *              ),
+     *              @SWG\Property(
+     *                  type="string",
+     *                  property="character_owner_hash",
+     *                  description="Eve Online account character hash"
+     *              ),
+     *              @SWG\Property(
+     *                  type="string",
+     *                  property="refresh_token",
+     *                  description="A refresh token for the account"
+     *              ),
+     *              @SWG\Property(
+     *                  type="array",
+     *                  @SWG\Items(type="string"),
+     *                  property="scopes",
+     *                  description="ESI scopes as array that are valid for the refresh token"
+     *              )
      *          )
      *      ),
      *      @SWG\Response(response=200, description="Successful operation"),

--- a/src/Http/Resources/AssetResource.php
+++ b/src/Http/Resources/AssetResource.php
@@ -23,6 +23,8 @@
 namespace Seat\Api\Http\Resources;
 
 use Illuminate\Http\Resources\Json\Resource;
+use Seat\Eveapi\Models\Assets\CharacterAsset;
+use Seat\Eveapi\Models\Assets\CorporationAsset;
 
 /**
  * Class AssetResource.
@@ -39,22 +41,17 @@ class AssetResource extends Resource
      */
     public function toArray($request)
     {
+        $definition = parent::toArray($request);
 
-        return [
-            'item_id'       => $this->item_id,
-            'type_id'       => $this->type_id,
-            'quantity'      => $this->quantity,
-            'location_id'   => $this->location_id,
-            'location_type' => $this->location_type,
-            'location_flag' => $this->location_flag,
-            'is_singleton'  => $this->is_singleton,
-            'x'             => $this->x,
-            'y'             => $this->y,
-            'z'             => $this->z,
-            'map_id'        => $this->map_id,
-            'map_name'      => $this->map_name,
-            'name'          => $this->name,
-            'type'          => $this->type,
-        ];
+        array_forget($definition, 'created_at');
+        array_forget($definition, 'updated_at');
+
+        if ($this->resource instanceof CorporationAsset)
+            array_forget($definition, 'corporation_id');
+
+        if ($this->resource instanceof CharacterAsset)
+            array_forget($definition, 'character_id');
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/CharacterSheetResource.php
+++ b/src/Http/Resources/CharacterSheetResource.php
@@ -36,21 +36,11 @@ class CharacterSheetResource extends Resource
     public function toArray($request)
     {
 
-        return [
-            'name'            => $this->name,
-            'description'     => $this->description,
-            'corporation_id'  => $this->corporation_id,
-            'alliance_id'     => $this->alliance_id,
-            'birthday'        => $this->birthday,
-            'gender'          => $this->gender,
-            'race_id'         => $this->race_id,
-            'bloodline_id'    => $this->bloodline_id,
-            'ancenstry_id'    => $this->ancenstry_id,
-            'security_status' => $this->security_status,
-            'faction_id'      => $this->faction_id,
-            'balance'         => $this->balance->balance,
-            'created_at'      => $this->created_at,
-            'updated_at'      => $this->updated_at,
-        ];
+        $definition = parent::toArray($request);
+
+        array_forget($definition, 'character_id');
+        array_set($definition, 'balance', array_get($definition, 'balance.balance'));
+
+        return  $definition;
     }
 }

--- a/src/Http/Resources/CorporationHistoryResource.php
+++ b/src/Http/Resources/CorporationHistoryResource.php
@@ -40,14 +40,10 @@ class CorporationHistoryResource extends Resource
     public function toArray($request)
     {
 
-        return [
+        $definition = parent::toArray($request);
 
-            'start_date'     => $this->start_date,
-            'corporation_id' => $this->corporation_id,
-            'is_deleted'     => $this->is_deleted,
-            'record_id'      => $this->record_id,
-            'created_at'     => $this->created_at,
-            'updated_at'     => $this->updated_at,
-        ];
+        array_forget($definition, 'character_id');
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/JumpcloneResource.php
+++ b/src/Http/Resources/JumpcloneResource.php
@@ -40,15 +40,10 @@ class JumpcloneResource extends Resource
     public function toArray($request)
     {
 
-        return [
-            'jump_clone_id' => $this->jump_clone_id,
-            'name'          => $this->name,
-            'location_id'   => $this->location_id,
-            'location_type' => $this->location_type,
-            'location'      => $this->location,
-            'implants'      => $this->implants,
-            'created_at'    => $this->created_at,
-            'updated_at'    => $this->updated_at,
-        ];
+        $definition = parent::toArray($request);
+
+        array_forget($definition, 'character_id');
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/KillmailDetailResource.php
+++ b/src/Http/Resources/KillmailDetailResource.php
@@ -39,15 +39,12 @@ class KillmailDetailResource extends Resource
      */
     public function toArray($request)
     {
+        $definition = parent::toArray($request);
 
-        return [
+        array_forget($definition, 'killmail_id');
+        array_forget($definition, 'created_at');
+        array_forget($definition, 'updated_at');
 
-            'killmail_time'   => $this->killmail_time,
-            'solar_system_id' => $this->solar_system_id,
-            'moon_id'         => $this->moon_id,
-            'war_id'          => $this->war_id,
-            'attackers'       => $this->attackers,
-            'victims'         => $this->victims,
-        ];
+        return $definition;
     }
 }

--- a/src/Http/Resources/KillmailResource.php
+++ b/src/Http/Resources/KillmailResource.php
@@ -23,6 +23,8 @@
 namespace Seat\Api\Http\Resources;
 
 use Illuminate\Http\Resources\Json\Resource;
+use Seat\Eveapi\Models\Killmails\CharacterKillmail;
+use Seat\Eveapi\Models\Killmails\CorporationKillmail;
 
 /**
  * Class KillmailResource.
@@ -40,6 +42,14 @@ class KillmailResource extends Resource
     public function toArray($request)
     {
 
-        return parent::toArray($request);
+        $definition = parent::toArray($request);
+
+        if ($this->resource instanceof CorporationKillmail)
+            array_forget($definition, 'corporation_id');
+
+        if ($this->resource instanceof CharacterKillmail)
+            array_forget($definition, 'character_id');
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/MailResource.php
+++ b/src/Http/Resources/MailResource.php
@@ -40,20 +40,19 @@ class MailResource extends Resource
     public function toArray($request)
     {
 
-        return [
-            'mail_id'    => $this->mail_id,
-            'subject'    => $this->subject,
-            'from'       => $this->from,
-            'timestamp'  => $this->timestamp,
-            'is_read'    => $this->is_read,
-            'body'       => $this->body->body,
-            'recipients' => $this->recipients->map(function ($recipient) {
+        $definition = parent::toArray($request);
 
-                return [
-                    'recipient_id'   => $recipient->recipient_id,
-                    'recipient_type' => $recipient->recipient_type,
-                ];
-            }),
-        ];
+        array_forget($definition, 'character_id');
+        array_forget($definition, 'created_at');
+        array_forget($definition, 'updated_at');
+        array_set($definition, 'body', array_get($definition, 'body.body'));
+        array_set($definition, 'recipients', array_map(function ($recipient) {
+            return [
+                'recipient_id' => $recipient['recipient_id'],
+                'recipient_type' => $recipient['recipient_type'],
+            ];
+        }, array_get($definition, 'recipients')));
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/MarketOrderResource.php
+++ b/src/Http/Resources/MarketOrderResource.php
@@ -23,6 +23,8 @@
 namespace Seat\Api\Http\Resources;
 
 use Illuminate\Http\Resources\Json\Resource;
+use Seat\Eveapi\Models\Market\CharacterOrder;
+use Seat\Eveapi\Models\Market\CorporationOrder;
 
 /**
  * Class MarketOrderResource.
@@ -40,6 +42,31 @@ class MarketOrderResource extends Resource
     public function toArray($request)
     {
 
-        return parent::toArray($request);
+        $definition = [
+            'order_id'          => $this->order_id,
+            'type_id'           => $this->type_id,
+            'region_id'         => $this->region_id,
+            'location_id'       => $this->location_id,
+            'range'             => $this->range,
+            'is_buy_order'      => $this->is_buy_order,
+            'price'             => $this->price,
+            'volume_total'      => $this->volume_total,
+            'volume_remain'     => $this->volume_remain,
+            'issued'            => $this->issued,
+            'min_volume'        => $this->min_volume,
+            'duration'          => $this->duration,
+            'escrow'            => $this->escrow,
+        ];
+
+        if ($this->resource instanceof CorporationOrder)
+            $definition['wallet_division'] = $this->wallet_division;
+
+        if ($this->resource instanceof CharacterOrder)
+            $definition['is_corporation'] = $this->is_corporation;
+
+        $definition = array_add($definition, 'created_at', $this->created_at);
+        $definition = array_add($definition, 'updated_at', $this->updated_at);
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/MarketOrderResource.php
+++ b/src/Http/Resources/MarketOrderResource.php
@@ -42,30 +42,13 @@ class MarketOrderResource extends Resource
     public function toArray($request)
     {
 
-        $definition = [
-            'order_id'          => $this->order_id,
-            'type_id'           => $this->type_id,
-            'region_id'         => $this->region_id,
-            'location_id'       => $this->location_id,
-            'range'             => $this->range,
-            'is_buy_order'      => $this->is_buy_order,
-            'price'             => $this->price,
-            'volume_total'      => $this->volume_total,
-            'volume_remain'     => $this->volume_remain,
-            'issued'            => $this->issued,
-            'min_volume'        => $this->min_volume,
-            'duration'          => $this->duration,
-            'escrow'            => $this->escrow,
-        ];
+        $definition = parent::toArray($request);
 
         if ($this->resource instanceof CorporationOrder)
-            $definition['wallet_division'] = $this->wallet_division;
+            array_forget($definition, 'corporation_id');
 
         if ($this->resource instanceof CharacterOrder)
-            $definition['is_corporation'] = $this->is_corporation;
-
-        $definition = array_add($definition, 'created_at', $this->created_at);
-        $definition = array_add($definition, 'updated_at', $this->updated_at);
+            array_forget($definition, 'character_id');
 
         return $definition;
     }

--- a/src/Http/Resources/NotificationResource.php
+++ b/src/Http/Resources/NotificationResource.php
@@ -40,17 +40,11 @@ class NotificationResource extends Resource
     public function toArray($request)
     {
 
-        return [
-            'id'              => $this->id,
-            'notification_id' => $this->notification_id,
-            'type'            => $this->type,
-            'sender_id'       => $this->sender_id,
-            'sender_type'     => $this->sender_type,
-            'timestamp'       => $this->timestamp,
-            'is_read'         => $this->is_read,
-            'text'            => $this->text,
-            'created_at'      => $this->created_at,
-            'updated_at'      => $this->updated_at,
-        ];
+        $definition = parent::toArray($request);
+
+        array_forget($definition, 'id');
+        array_forget($definition, 'character_id');
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/SkillQueueResource.php
+++ b/src/Http/Resources/SkillQueueResource.php
@@ -36,18 +36,10 @@ class SkillQueueResource extends Resource
     public function toArray($request)
     {
 
-        return [
-            'skill_id'          => $this->skill_id,
-            'finish_date'       => $this->finish_date,
-            'start_date'        => $this->start_date,
-            'finished_level'    => $this->finished_level,
-            'queue_position'    => $this->queue_position,
-            'training_start_sp' => $this->training_start_sp,
-            'level_end_sp'      => $this->level_end_sp,
-            'level_start_sp'    => $this->level_start_sp,
-            'type'              => $this->type,
-            'created_at'        => $this->created_at,
-            'updated_at'        => $this->updated_at,
-        ];
+        $definition = parent::toArray($request);
+
+        array_forget($definition, 'character_id');
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/SkillsResource.php
+++ b/src/Http/Resources/SkillsResource.php
@@ -40,12 +40,12 @@ class SkillsResource extends Resource
     public function toArray($request)
     {
 
-        return [
-            'skill_id'             => $this->skill_id,
-            'skillpoints_in_skill' => $this->skillpoints_in_skill,
-            'trained_skill_level'  => $this->trained_skill_level,
-            'active_skill_level'   => $this->active_skill_level,
-            'type'                 => $this->type,
-        ];
+        $definition = parent::toArray($request);
+
+        array_forget($definition, 'character_id');
+        array_forget($definition, 'created_at');
+        array_forget($definition, 'updated_at');
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/WalletJournalResource.php
+++ b/src/Http/Resources/WalletJournalResource.php
@@ -23,6 +23,8 @@
 namespace Seat\Api\Http\Resources;
 
 use Illuminate\Http\Resources\Json\Resource;
+use Seat\Eveapi\Models\Wallet\CharacterWalletJournal;
+use Seat\Eveapi\Models\Wallet\CorporationWalletJournal;
 
 class WalletJournalResource extends Resource
 {
@@ -36,25 +38,14 @@ class WalletJournalResource extends Resource
     public function toArray($request)
     {
 
-        return [
+        $definition = parent::toArray($request);
 
-            'id'              => $this->id,
-            'date'            => $this->date,
-            'ref_type'        => $this->ref_type,
-            'first_party_id'  => $this->first_party_id,
-            'first_party'     => $this->first_party,
-            'second_party_id' => $this->second_party_id,
-            'second_party'    => $this->second_party,
-            'amount'          => $this->amount,
-            'balance'         => $this->balance,
-            'reason'          => $this->reason,
-            'tax_receiver_id' => $this->tax_receiver_id,
-            'tax'             => $this->tax,
-            'context_id'      => $this->context_id,
-            'context_id_type' => $this->context_id_type,
-            'description'     => $this->description,
-            'created_at'      => $this->created_at,
-            'updated_at'      => $this->updated_at,
-        ];
+        if ($this->resource instanceof CorporationWalletJournal)
+            array_forget($definition, 'corporation_id');
+
+        if ($this->resource instanceof CharacterWalletJournal)
+            array_forget($definition, 'character_id');
+
+        return $definition;
     }
 }

--- a/src/Http/Resources/WalletTransactionResource.php
+++ b/src/Http/Resources/WalletTransactionResource.php
@@ -23,6 +23,8 @@
 namespace Seat\Api\Http\Resources;
 
 use Illuminate\Http\Resources\Json\Resource;
+use Seat\Eveapi\Models\Wallet\CharacterWalletTransaction;
+use Seat\Eveapi\Models\Wallet\CorporationWalletTransaction;
 
 /**
  * Class WalletTransactionResource.
@@ -40,20 +42,16 @@ class WalletTransactionResource extends Resource
     public function toArray($request)
     {
 
-        return [
-            'transaction_id' => $this->transaction_id,
-            'date'           => $this->date,
-            'type_id'        => $this->type_id,
-            'location_id'    => $this->location_id,
-            'unit_price'     => $this->unit_price,
-            'quantity'       => $this->quantity,
-            'client_id'      => $this->client_id,
-            'is_buy'         => $this->is_buy,
-            'is_personal'    => $this->is_personal,
-            'journal_ref_id' => $this->journal_ref_id,
-            'type'           => $this->type,
-            'created_at'     => $this->created_at,
-            'updated_at'     => $this->updated_at,
-        ];
+        $definition = parent::toArray($request);
+
+        if ($this->resource instanceof CorporationWalletTransaction)
+            array_forget($definition, 'corporation_id');
+
+        if ($this->resource instanceof CharacterWalletTransaction)
+            array_forget($definition, 'character_id');
+
+        array_forget($definition, 'type_id');
+
+        return $definition;
     }
 }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -91,7 +91,7 @@ Route::group([
 
             Route::group(['prefix' => 'killmails'], function () {
 
-                Route::get('/detail/{killmail_id}', 'KillmailsController@getDetail');
+                Route::get('/{killmail_id}', 'KillmailsController@getDetail');
             });
 
             Route::group(['prefix' => 'character'], function () {

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -73,11 +73,11 @@ Route::group([
             Route::group(['prefix' => 'roles'], function () {
 
                 Route::get('/', 'RoleController@getIndex');
-                Route::get('/detail/{role_id}', 'RoleController@getDetail');
-                Route::post('/new', 'RoleController@postNew');
-                Route::delete('/delete/{role_id}', 'RoleController@deleteRole');
-                Route::get('/grant-user-role/{user_id}/{role_id}', 'RoleController@getGrantUserRole');
-                Route::get('/revoke-user-role/{user_id}/{role_id}', 'RoleController@getRevokeUserRole');
+                Route::get('/{role_id}', 'RoleController@getDetail')->where('role_id', '[0-9]+');
+                Route::post('/', 'RoleController@postNew');
+                Route::delete('/{role_id}', 'RoleController@deleteRole')->where('role_id', '[0-9]+');
+                Route::post('/groups', 'RoleController@postGrantUserRole');
+                Route::delete('/groups/{group_id}/{role_id}', 'RoleController@deleteRevokeGroupRole');
                 Route::post('/affiliation/character', 'RoleController@postAddCharacterAffiliation');
                 Route::post('/affiliation/corporation', 'RoleController@postAddCorporationAffiliation');
 


### PR DESCRIPTION
include PR eveseat/api#19 as it's required in order to retrieve model annotations.

Dependencies :
- eveseat/eveapi#108 : contains models annotations and some fixes related to cast
- eveseat/web#196 : contains models annotations related to ACL

Improvements :
- Provide extended documentation; including model definition of each endpoint response (200)
- Use multiple directories annotations source for swagger documentation generator
- Ensure all endpoint have a REST syntax
- Simplifying resource definition by calling main method and remove filtered fields (models updates are easier)

Fixes :
- Fix body endpoint documentation definition (as body is a field itself which will contains json model)
- Fix roles endpoints according to modification introduced pre release