### PR TITLE
fix issue which was preventing to use swagger UI to test endpoints

### DIFF
--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -66,7 +66,9 @@ class CharacterController extends ApiController
      *      tags={"Assets"},
      *      summary="Get a paginated list of a assets for a character",
      *      description="Returns a list of assets",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -84,7 +86,9 @@ class CharacterController extends ApiController
      *      tags={"Assets"},
      *      summary="Get a specific asset",
      *      description="Returns list of assets",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -126,7 +130,9 @@ class CharacterController extends ApiController
      *      tags={"Bookmarks"},
      *      summary="Get a paginated list of bookmarks for a character",
      *      description="Returns a list of bookmarks",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -153,7 +159,9 @@ class CharacterController extends ApiController
      *      tags={"Contacts"},
      *      summary="Get a paginated list of contacts for a character",
      *      description="Returns list of contacs",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -183,7 +191,9 @@ class CharacterController extends ApiController
      *      tags={"Contracts"},
      *      summary="Get a paginated list of contracts for a character",
      *      description="Returns list of contracts",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -213,7 +223,9 @@ class CharacterController extends ApiController
      *      tags={"Character"},
      *      summary="Get the corporation history for a character",
      *      description="Returns a corporation history",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -243,7 +255,9 @@ class CharacterController extends ApiController
      *      tags={"Industry"},
      *      summary="Get a paginated list of industry jobs for a character",
      *      description="Returns list of industry jobs",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -273,7 +287,9 @@ class CharacterController extends ApiController
      *      tags={"Character"},
      *      summary="Get a paginated list of jump clones for a character",
      *      description="Returns list of jump clones",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -303,7 +319,9 @@ class CharacterController extends ApiController
      *      tags={"Killmails"},
      *      summary="Get a paginated list of killmails for a character",
      *      description="Returns list of killmails",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -333,7 +351,9 @@ class CharacterController extends ApiController
      *      tags={"Character"},
      *      summary="Get a paginated list of mail for a character",
      *      description="Returns mail",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -362,7 +382,9 @@ class CharacterController extends ApiController
      *      tags={"Market"},
      *      summary="Get a paginated list of market orders for a character",
      *      description="Returns list of market orders",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -392,7 +414,9 @@ class CharacterController extends ApiController
      *      tags={"Character"},
      *      summary="Get a paginated list of notifications for a character",
      *      description="Returns a list of notifications",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -422,7 +446,9 @@ class CharacterController extends ApiController
      *      tags={"Character"},
      *      summary="Get the character sheet for a character",
      *      description="Returns a character sheet",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -451,7 +477,9 @@ class CharacterController extends ApiController
      *      tags={"Character"},
      *      summary="Get the skills for a character",
      *      description="Returns character skills",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -480,7 +508,9 @@ class CharacterController extends ApiController
      *      tags={"Character"},
      *      summary="Get a list of characters skill queue",
      *      description="Returns a skill queue",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -509,7 +539,9 @@ class CharacterController extends ApiController
      *      tags={"Wallet"},
      *      summary="Get a paginated wallet journal for a character",
      *      description="Returns a wallet journal",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -539,7 +571,9 @@ class CharacterController extends ApiController
      *      tags={"Wallet"},
      *      summary="Get paginated wallet transactions for a character",
      *      description="Returns wallet transactions",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -57,7 +57,9 @@ class CorporationController extends ApiController
      *      tags={"Assets"},
      *      summary="Get a paginated list of a assets for a corporation",
      *      description="Returns a list of assets",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -87,7 +89,9 @@ class CorporationController extends ApiController
      *      tags={"Bookmarks"},
      *      summary="Get a list of bookmarks for a corporation",
      *      description="Returns a list of bookmarks",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -116,7 +120,9 @@ class CorporationController extends ApiController
      *      tags={"Contacts"},
      *      summary="Get a list of contacts for a corporation",
      *      description="Returns a list of contacts",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -146,7 +152,9 @@ class CorporationController extends ApiController
      *      tags={"Contracts"},
      *      summary="Get a paginated list of contracts for a corporation",
      *      description="Returns a list of contracts",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -176,7 +184,9 @@ class CorporationController extends ApiController
      *      tags={"Industry"},
      *      summary="Get a paginated list of industry jobs for a corporation",
      *      description="Returns a list of industry jobs",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -206,7 +216,9 @@ class CorporationController extends ApiController
      *      tags={"Killmails"},
      *      summary="Get a paginated list of killmails for a corporation",
      *      description="Returns a list of killmails",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -236,7 +248,9 @@ class CorporationController extends ApiController
      *      tags={"Market"},
      *      summary="Get a paginated list of market orders for a corporation",
      *      description="Returns a list of market orders",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -266,7 +280,9 @@ class CorporationController extends ApiController
      *      tags={"Corporation"},
      *      summary="Get a list of members for a corporation with tracking",
      *      description="Returns a list of members for a corporation",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -296,7 +312,9 @@ class CorporationController extends ApiController
      *      tags={"Corporation"},
      *      summary="Get a corporation sheet",
      *      description="Returns a corporation sheet",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -325,7 +343,9 @@ class CorporationController extends ApiController
      *      tags={"Wallet"},
      *      summary="Get a paginated wallet journal for a corporation",
      *      description="Returns a wallet journal",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",
@@ -355,7 +375,9 @@ class CorporationController extends ApiController
      *      tags={"Wallet"},
      *      summary="Get paginated wallet transactions for a corporation",
      *      description="Returns wallet transactions",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="corporation_id",
      *          description="Corporation id",

--- a/src/Http/Controllers/Api/v2/KillmailsController.php
+++ b/src/Http/Controllers/Api/v2/KillmailsController.php
@@ -37,7 +37,9 @@ class KillmailsController extends ApiController
      *      tags={"Killmails"},
      *      summary="Get full details about a killmail",
      *      description="Returns a detailed killmail",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="killmail_id",
      *          description="Killmail id",

--- a/src/Http/Controllers/Api/v2/RoleController.php
+++ b/src/Http/Controllers/Api/v2/RoleController.php
@@ -43,7 +43,9 @@ class RoleController extends Controller
      *      tags={"Roles"},
      *      summary="Get the roles configured within SeAT",
      *      description="Returns a list of roles",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Response(response=200, description="Successful operation"),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
@@ -65,7 +67,9 @@ class RoleController extends Controller
      *      tags={"Roles"},
      *      summary="Get detailed information about a role",
      *      description="Returns a roles details",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="role_id",
      *          description="Role id",
@@ -98,7 +102,9 @@ class RoleController extends Controller
      *      tags={"Roles"},
      *      summary="Create a new SeAT role",
      *      description="Creates a role",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="name",
      *          description="A role name",
@@ -132,7 +138,9 @@ class RoleController extends Controller
      *      tags={"Roles"},
      *      summary="Add a character affiliation to a SeAT role",
      *      description="Adds a character affiliation",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="role_id",
      *          description="Role id",
@@ -190,7 +198,9 @@ class RoleController extends Controller
      *      tags={"Roles"},
      *      summary="Add a corporation affiliation to a SeAT role",
      *      description="Adds a corporation affiliation",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="role_id",
      *          description="Role id",
@@ -248,7 +258,9 @@ class RoleController extends Controller
      *      tags={"Roles"},
      *      summary="Delete a SeAT role",
      *      description="Deletes a role",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="role_id",
      *          description="Role id",
@@ -279,7 +291,9 @@ class RoleController extends Controller
      *      tags={"Roles"},
      *      summary="Grant a user a SeAT role",
      *      description="Grants a role",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="user_id",
      *          description="User id",
@@ -319,7 +333,9 @@ class RoleController extends Controller
      *      tags={"Roles"},
      *      summary="Revoke a SeAT role from a user",
      *      description="Revokes a role",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="user_id",
      *          description="User id",

--- a/src/Http/Controllers/Api/v2/RoleLookupController.php
+++ b/src/Http/Controllers/Api/v2/RoleLookupController.php
@@ -37,7 +37,9 @@ class RoleLookupController extends Controller
      *      tags={"Roles"},
      *      summary="Get the available SeAT permissions",
      *      description="Returns a list of permissions",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Response(response=200, description="Successful operation"),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
@@ -57,7 +59,9 @@ class RoleLookupController extends Controller
      *      tags={"Roles"},
      *      summary="Check if a user has a role",
      *      description="Returns a boolean",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",
@@ -96,7 +100,9 @@ class RoleLookupController extends Controller
      *      tags={"Roles"},
      *      summary="Check if a user has a role",
      *      description="Returns a boolean",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="character_id",
      *          description="Character id",

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -42,7 +42,9 @@ class UserController extends Controller
      *      tags={"Users"},
      *      summary="Get a list of users, associated character id's and group ids",
      *      description="Returns list of users",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Response(response=200, description="Successful operation"),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
@@ -53,7 +55,9 @@ class UserController extends Controller
      *      tags={"Users"},
      *      summary="Get group id's and assosciated character_id's for a user",
      *      description="Returns a user",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="user_id",
      *          description="User id",
@@ -85,7 +89,9 @@ class UserController extends Controller
      *      tags={"Users"},
      *      summary="Get a list of groups with their associated character_id's",
      *      description="Returns list of groups",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Response(response=200, description="Successful operation"),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
@@ -96,7 +102,9 @@ class UserController extends Controller
      *      tags={"Users"},
      *      summary="Get a group with its associated character_id's",
      *      description="Returns a group",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="group_id",
      *          description="Group id",
@@ -128,7 +136,9 @@ class UserController extends Controller
      *      tags={"Users"},
      *      summary="Get a list of the scopes configured for this instance",
      *      description="Returns list of scopes",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Response(response=200, description="Successful operation"),
      *      @SWG\Response(response=400, description="Bad request"),
      *      @SWG\Response(response=401, description="Unauthorized"),
@@ -150,7 +160,9 @@ class UserController extends Controller
      *      tags={"Users"},
      *      summary="Create a new SeAT user",
      *      description="Creates a new SeAT user",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="user_id",
      *          description="Eve Online Character ID",
@@ -243,7 +255,9 @@ class UserController extends Controller
      *      tags={"Users"},
      *      summary="Delete a SeAT user",
      *      description="Deletes a user",
-     *      security={"ApiKeyAuth"},
+     *      security={
+     *          {"ApiKeyAuth": {}}
+     *      },
      *      @SWG\Parameter(
      *          name="user_id",
      *          description="A SeAT user id",


### PR DESCRIPTION
An error in security attribute usage was preventing swagger UI to work properly.
All endpoints are currently public - which explains while even by providing a valid token; it was not sending the header.

Security attribute seems to be an array including "authentication provider" and "default value".

This commit is solving the issue.