### PR TITLE
feat(icons): Upgrade package to handle font-awesome 5 properly

### DIFF
--- a/src/Config/package.sidebar.php
+++ b/src/Config/package.sidebar.php
@@ -25,7 +25,7 @@ return [
     'seatapi' => [
         'permission'    => 'Superuser',
         'name'          => 'SeAT API',
-        'icon'          => 'fa-exchange',
+        'icon'          => 'fas fa-exchange-alt',
         'route_segment' => 'api-admin',
         'route'         => 'api-admin.list',
     ],

--- a/src/resources/views/logs.blade.php
+++ b/src/resources/views/logs.blade.php
@@ -32,7 +32,7 @@
             </td>
             <td @if($log->action == 'deny')class="danger"@endif>
               @if($log->action == 'deny')
-                <i class="fa fa-warning"></i>
+                <i class="fas fa-exclamation-triangle"></i>
               @endif
               {{ ucfirst($log->action) }}
             </td>


### PR DESCRIPTION
Bump icons dependencies to FA5 which provide us lot of new icons, especially brands on.
Both AdminLTE stylesheet and blades has been updated.

Move the `fa` class to package sidebar icons value as since 5.x, there are 4 distinct styling :
 - `fas` which is mainly the previous `fa`
 - `far` which is under license except for icons renamed from FA4
 - `fal` which is under license
 - `fab` which is providing all "business" icons, like Discord brand, Slack brand, etc...

**In case blades are updated since API 3.0.5, double check they are properly updated by this package**