### PR TITLE
fix(api): remove the type attribute on body POST and switched it in schema

### DIFF
--- a/src/Http/Controllers/Api/v2/RoleController.php
+++ b/src/Http/Controllers/Api/v2/RoleController.php
@@ -278,12 +278,12 @@ class RoleController extends Controller
      *          {"ApiKeyAuth": {}}
      *      },
      *      @SWG\Parameter(
-     *          type="object",
      *          name="body",
      *          in="body",
      *          required=true,
      *          @SWG\Schema(
      *              required={"title"},
+     *              type="object",
      *              @SWG\Property(
      *                  type="string",
      *                  property="title",
@@ -365,11 +365,12 @@ class RoleController extends Controller
      *          in="path"
      *      ),
      *      @SWG\Parameter(
-     *          type="object",
      *          name="body",
      *          in="body",
+     *          required=true,
      *          @SWG\Schema(
      *              required={"title"},
+     *              type="object",
      *              @SWG\Property(
      *                  type="string",
      *                  property="title",
@@ -430,12 +431,12 @@ class RoleController extends Controller
      *          {"ApiKeyAuth": {}}
      *      },
      *      @SWG\Parameter(
-     *          type="object",
      *          name="body",
      *          in="body",
      *          required=true,
      *          @SWG\Schema(
      *              required={"role_id", "character_id"},
+     *              type="object",
      *              @SWG\Property(
      *                  type="integer",
      *                  minimum=1,
@@ -492,12 +493,12 @@ class RoleController extends Controller
      *          {"ApiKeyAuth": {}}
      *      },
      *      @SWG\Parameter(
-     *          type="object",
      *          name="body",
      *          in="body",
      *          required=true,
      *          @SWG\Schema(
      *              required={"role_id", "corporation_id"},
+     *              type="object",
      *              @SWG\Property(
      *                  type="integer",
      *                  minimum=1,
@@ -587,11 +588,12 @@ class RoleController extends Controller
      *          {"ApiKeyAuth": {}}
      *      },
      *      @SWG\Parameter(
-     *          type="object",
      *          name="body",
      *          in="body",
+     *          required=true,
      *          @SWG\Schema(
      *              required={"group_id", "role_id"},
+     *              type="object",
      *              @SWG\Property(
      *                  type="integer",
      *                  minimum=1,

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -273,12 +273,12 @@ class UserController extends Controller
      *          {"ApiKeyAuth": {}}
      *      },
      *      @SWG\Parameter(
-     *          type="object",
      *          name="body",
      *          in="body",
      *          required=true,
      *          @SWG\Schema(
      *              required={"user_id", "name", "character_owner_hash", "refresh_token", "scopes"},
+     *              type="object",
      *              @SWG\Property(
      *                  type="integer",
      *                  format="int64",


### PR DESCRIPTION
The object type is related to the body content and not the body itself.
Doing it so will allow people to send request using Swagger UI.