### PR TITLE
Enforce json

### DIFF
--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -23,6 +23,7 @@
 namespace Seat\Api;
 
 use Illuminate\Routing\Router;
+use Seat\Api\Http\Middleware\ApiRequest;
 use Seat\Api\Http\Middleware\ApiToken;
 use Seat\Services\AbstractSeatPlugin;
 
@@ -110,6 +111,9 @@ class ApiServiceProvider extends AbstractSeatPlugin
         // Authenticate checks that the token is valid
         // from an allowed IP address
         $router->aliasMiddleware('api.auth', ApiToken::class);
+
+        // Ensure incoming request is formed using JSON
+        $router->aliasMiddleware('api.request', ApiRequest::class);
 
     }
 

--- a/src/Http/Controllers/Api/v2/RoleController.php
+++ b/src/Http/Controllers/Api/v2/RoleController.php
@@ -24,7 +24,6 @@ namespace Seat\Api\Http\Controllers\Api\v2;
 
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Controller;
 use Seat\Api\Http\Validation\RenameRole;
 use Seat\Web\Acl\AccessManager;
 use Seat\Web\Models\Acl\Role;
@@ -33,7 +32,7 @@ use Seat\Web\Models\Acl\Role;
  * Class RoleController.
  * @package Seat\Api\Http\Controllers\Api\v1
  */
-class RoleController extends Controller
+class RoleController extends ApiController
 {
     use AccessManager;
     use ValidatesRequests;

--- a/src/Http/Controllers/Api/v2/RoleLookupController.php
+++ b/src/Http/Controllers/Api/v2/RoleLookupController.php
@@ -22,14 +22,13 @@
 
 namespace Seat\Api\Http\Controllers\Api\v2;
 
-use Illuminate\Routing\Controller;
 use Seat\Web\Models\User;
 
 /**
  * Class RoleLookupController.
  * @package Seat\Api\Http\Controllers\Api\v1
  */
-class RoleLookupController extends Controller
+class RoleLookupController extends ApiController
 {
     /**
      * @SWG\Get(

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -22,7 +22,6 @@
 
 namespace Seat\Api\Http\Controllers\Api\v2;
 
-use Illuminate\Routing\Controller;
 use Seat\Api\Http\Resources\GroupResource;
 use Seat\Api\Http\Resources\UserResource;
 use Seat\Api\Http\Validation\NewUser;
@@ -34,7 +33,7 @@ use Seat\Web\Models\User;
  * Class UserController.
  * @package Seat\Api\Http\Controllers\Api\v2
  */
-class UserController extends Controller
+class UserController extends ApiController
 {
     /**
      * @SWG\Get(

--- a/src/Http/Middleware/ApiRequest.php
+++ b/src/Http/Middleware/ApiRequest.php
@@ -35,7 +35,7 @@ class ApiRequest
     public function handle($request, Closure $next)
     {
         if ($request->headers->has('Accept') && ! in_array($request->headers->get('Accept'), ['', '*/*', 'application/json']))
-            return response()->json('This api is only returning application/json structures', 406);
+            return response()->json("Invalid Accept header. Either accept all response types, or specify 'application/json'.", 406);
 
         // force return to be JSON formatted
         $request->server->set('HTTP_ACCEPT', 'application/json');
@@ -43,7 +43,7 @@ class ApiRequest
 
         // ensure the request has been made using application/json (for PATCH, PUT or POST queries)
         if ($request->headers->has('Content-Type') && ! in_array($request->headers->get('Content-Type'), ['', 'application/json']))
-            return response()->json('This api is only accepting application/json formatted query', 415);
+            return response()->json("Invalid Content-type header. Only the 'application/json' type is accepted.", 415);
 
         return $next($request);
     }

--- a/src/Http/Middleware/ApiRequest.php
+++ b/src/Http/Middleware/ApiRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Api\Http\Middleware;
+
+use Closure;
+use Symfony\Component\HttpFoundation\HeaderBag;
+
+class ApiRequest
+{
+    /**
+     * @param $request
+     * @param \Closure $next
+     * @return mixed|void
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($request->headers->has('Accept') && ! in_array($request->headers->get('Accept'), ['', '*/*', 'application/json']))
+            return response()->json('This api is only returning application/json structures', 406);
+
+        // force return to be JSON formatted
+        $request->server->set('HTTP_ACCEPT', 'application/json');
+        $request->headers = new HeaderBag($request->server->getHeaders());
+
+        // ensure the request has been made using application/json (for PATCH, PUT or POST queries)
+        if ($request->headers->has('Content-Type') && ! in_array($request->headers->get('Content-Type'), ['', 'application/json']))
+            return response()->json('This api is only accepting application/json formatted query', 415);
+
+        return $next($request);
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -52,7 +52,7 @@ Route::group([
     // Http Routes to the SeAT API itself
     Route::group([
         'namespace'  => 'Api',
-        'middleware' => 'api.auth',
+        'middleware' => ['api.request', 'api.auth'],
         'prefix'     => 'api',
     ], function () {
 


### PR DESCRIPTION
In order to ensure JSON structure are expected and sent, this PR is providing a new Middleware in charge of such check.

- In case the provided `Accept` header is not meeting our requirement, an HTTP 406 will be returned
- In case the provided `Content-Type` header is not meeting our requirement, an HTTP 415 will be returned