### PR TITLE
SEAT api change to include main character id

### DIFF
--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -166,7 +166,7 @@ class UserController extends ApiController
         if (! is_null($user_id))
             return new UserResource(User::findOrFail($user_id));
 
-        return UserResource::collection(User::paginate());
+        return UserResource::collection(User::with('group')->paginate());
     }
 
     /**

--- a/src/Http/Resources/UserResource.php
+++ b/src/Http/Resources/UserResource.php
@@ -51,6 +51,7 @@ class UserResource extends Resource
             'last_login_source'        => $this->last_login_source,
             'group_id'                 => $this->group->id,
             'associated_character_ids' => $this->associatedCharacterIds(),
+            'main_character_id'        => $this->group->main_character_id,
             'token'                    => $this->refresh_token,
         ];
     }


### PR DESCRIPTION
This will allow callers of the SEAT api access to the main character id of a user.

This is mostly helpful to those who use SEAT internally and have other functions that check across all characters owned by "someone".