### PR TITLE
refactor(core): move AbstractSeatPlugin from services to seat package

### DIFF
--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -22,11 +22,11 @@
 
 namespace Seat\Api;
 
+use App\Providers\AbstractSeatPlugin;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Str;
 use Seat\Api\Http\Middleware\ApiRequest;
 use Seat\Api\Http\Middleware\ApiToken;
-use Seat\Services\AbstractSeatPlugin;
 
 /**
  * Class ApiServiceProvider.


### PR DESCRIPTION
in order to keep consistency with packages, AbstractSeatPlugin is
moved to main package - as it will be extended by every single seat
packages (core and third party).