### PR TITLE
feat: add option for blanket api access

### DIFF
--- a/src/Http/Middleware/ApiToken.php
+++ b/src/Http/Middleware/ApiToken.php
@@ -65,17 +65,10 @@ class ApiToken
      */
     public function valid_token_ip(Request $request)
     {
-        $specific = ApiTokenModel::where('token', $request->header('X-Token'))
-                        ->where('allowed_src', $request->getClientIp())
+        $tk = ApiTokenModel::where('token', $request->header('X-Token'))
                         ->first();
 
-        if ($specific) {
-            return $specific;
-        }
-
-        return ApiTokenModel::where('token', $request->header('X-Token'))
-                ->where('allowed_src', '0.0.0.0')
-                ->first();
+        return $tk && ($tk->allowed_src == $request->getClientIp() || $tk->allowed_src == '0.0.0.0');
     }
 
     /**

--- a/src/Http/Middleware/ApiToken.php
+++ b/src/Http/Middleware/ApiToken.php
@@ -65,10 +65,17 @@ class ApiToken
      */
     public function valid_token_ip(Request $request)
     {
+        $specific = ApiTokenModel::where('token', $request->header('X-Token'))
+                        ->where('allowed_src', $request->getClientIp())
+                        ->first();
+
+        if ($specific) {
+            return $specific;
+        }
 
         return ApiTokenModel::where('token', $request->header('X-Token'))
-            ->where('allowed_src', $request->getClientIp())
-            ->first();
+                ->where('allowed_src', '0.0.0.0')
+                ->first();
     }
 
     /**

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -27,6 +27,7 @@ return [
     'key_comment'        => 'Key Comment',
     'allowed_ip_address' => 'Allowed IP Address',
     'ip_help'            => 'This is the source IP address that will be allowed to use the generated token.',
+    'ip_danger'          => 'Using 0.0.0.0 will allow ANYONE who has this token to use the SeAT API. This is dangerous. Be careful!',
     'generate'           => 'Generate',
     'token'              => 'Token|Tokens',
     'current_tokens'     => 'Current Tokens',

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -39,6 +39,9 @@
             <span class="help-block">
               {{ trans('api::seat.ip_help') }}
             </span>
+            <div class="card bg-danger p-1">
+              {{ trans('api::seat.ip_danger') }}
+            </div>
           </div>
 
         </div>


### PR DESCRIPTION
Addresses https://github.com/eveseat/seat/issues/186

This is not as fancy as CIDR notation. But 0.0.0.0 is familiar to web devs as allow from anywhere so seems appropriate.

There is no button to punch saying I accept responsibility etc etc. However there is a permanently displayed warning about it.