### PR TITLE
Allowing for permissions to be set on new roles

### DIFF
--- a/src/Http/Controllers/Api/v2/RoleController.php
+++ b/src/Http/Controllers/Api/v2/RoleController.php
@@ -209,6 +209,11 @@ class RoleController extends ApiController
 
         $role->save();
 
+        if ($request->has('permissions'))
+            $this->giveRolePermissions($role->id, $request->input('permissions'), false);
+
+        $role = Role::find($role->id);
+
         return RoleResource::make($role);
     }
 

--- a/src/Http/Validation/NewRole.php
+++ b/src/Http/Validation/NewRole.php
@@ -53,6 +53,7 @@ class NewRole extends FormRequest
         return [
             'title' => 'string|unique:roles,title|required',
             'description' => 'string',
+            'permissions' => 'array',
             'logo' => 'base64image',
         ];
     }


### PR DESCRIPTION
This PR allows for permissions to be added to a role at creation time. This is useful for creating roles programatically (such as with Terraform, or an external application).