### PR TITLE
Destinguish between string  and other values

### DIFF
--- a/src/Http/Traits/Filterable.php
+++ b/src/Http/Traits/Filterable.php
@@ -41,7 +41,7 @@ trait Filterable
      */
     protected function applyFilters(Request $request, Builder $query)
     {
-        $regex = "/((?'field'[a-z_]+) (?'operator'eq|ne|gt|lt|ge|le) (?'value''?[a-z0-9_ ]+'?)( (?'join'and|or))?)+/";
+        $regex = "/((?'field'[a-z_]+)\s+(?'operator'eq|ne|gt|lt|ge|le)\s+(?'value'(?>'[a-z0-9_ ]+')|(?>[a-z0-9_]+))\s*((?'join'and|or))?)+/";
         if (preg_match_all($regex, $request->query('$filter', ''), $filters) === false)
             return $query;
 

--- a/src/Http/Traits/Filterable.php
+++ b/src/Http/Traits/Filterable.php
@@ -41,7 +41,7 @@ trait Filterable
      */
     protected function applyFilters(Request $request, Builder $query)
     {
-        $regex = "/((?'field'[a-z_]+)\s+(?'operator'eq|ne|gt|lt|ge|le)\s+(?'value'(?>'[a-z0-9_ ]+')|(?>[a-z0-9_]+))\s*((?'join'and|or))?)+/";
+        $regex = "((?'field'[a-z_]+)\s+(?'operator'eq|ne|gt|lt|ge|le)\s+(?'value'(?>'[a-z0-9_\s]+')|(?>[a-z0-9_]+))(\s+(?'join'and|or))?)+";
         if (preg_match_all($regex, $request->query('$filter', ''), $filters) === false)
             return $query;
 

--- a/src/Http/Traits/Filterable.php
+++ b/src/Http/Traits/Filterable.php
@@ -41,7 +41,7 @@ trait Filterable
      */
     protected function applyFilters(Request $request, Builder $query)
     {
-        $regex = "((?'field'[a-z_]+)\s+(?'operator'eq|ne|gt|lt|ge|le)\s+(?'value'(?>'[a-z0-9_\s]+')|(?>[a-z0-9_]+))(\s+(?'join'and|or))?)+";
+        $regex = "((/?'field'[a-z_]+)\s+(?'operator'eq|ne|gt|lt|ge|le)\s+(?'value'(?>'[a-z0-9_\s]+')|(?>[a-z0-9_]+))(\s+(?'join'and|or))?)+/";
         if (preg_match_all($regex, $request->query('$filter', ''), $filters) === false)
             return $query;
 

--- a/src/Http/Traits/Filterable.php
+++ b/src/Http/Traits/Filterable.php
@@ -41,7 +41,7 @@ trait Filterable
      */
     protected function applyFilters(Request $request, Builder $query)
     {
-        $regex = "((/?'field'[a-z_]+)\s+(?'operator'eq|ne|gt|lt|ge|le)\s+(?'value'(?>'[a-z0-9_\s]+')|(?>[a-z0-9_]+))(\s+(?'join'and|or))?)+/";
+        $regex = "/((?'field'[a-z_]+)\s+(?'operator'eq|ne|gt|lt|ge|le)\s+(?'value'(?>'[a-z0-9_\s]+')|(?>[a-z0-9_]+))(\s+(?'join'and|or))?)+/";
         if (preg_match_all($regex, $request->query('$filter', ''), $filters) === false)
             return $query;
 


### PR DESCRIPTION
The former Regex was allowed to capture a `'` wihtout capturing a second `'` for string values. This resulted in malformed captures.
This fix proposes two non capturing groups for string values and any other value. Additionaly whitespaces are now captured outside the capture groups.

To see the Regex in action visit: https://regex101.com/r/qzkwPT/2