### PR TITLE
feat: ensure query filter are append to paginated links

### DIFF
--- a/src/Http/Controllers/Api/v2/CharacterController.php
+++ b/src/Http/Controllers/Api/v2/CharacterController.php
@@ -120,7 +120,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -185,7 +185,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return ContactResource::collection($query->paginate());
+        return ContactResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -253,7 +253,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return ContractResource::collection($query->paginate());
+        return ContractResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -318,7 +318,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return CorporationHistoryResource::collection($query->paginate());
+        return CorporationHistoryResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -383,7 +383,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return IndustryResource::collection($query->paginate());
+        return IndustryResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -448,7 +448,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return JumpcloneResource::collection($query->paginate());
+        return JumpcloneResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -517,7 +517,7 @@ class CharacterController extends ApiController
                 })->orWhere('from', $character_id);
             });
 
-        return MailResource::collection($query->paginate());
+        return MailResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -583,7 +583,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -648,7 +648,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return NotificationResource::collection($query->paginate());
+        return NotificationResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -756,7 +756,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -821,7 +821,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -887,7 +887,7 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -953,6 +953,6 @@ class CharacterController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 }

--- a/src/Http/Controllers/Api/v2/CorporationController.php
+++ b/src/Http/Controllers/Api/v2/CorporationController.php
@@ -112,7 +112,7 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -178,7 +178,7 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return ContactResource::collection($query->paginate());
+        return ContactResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -244,7 +244,7 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return ContractResource::collection($query->paginate());
+        return ContractResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -310,7 +310,7 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return IndustryResource::collection($query->paginate());
+        return IndustryResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -376,7 +376,7 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -442,7 +442,7 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return MemberTrackingResource::collection($query->paginate());
+        return MemberTrackingResource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -543,7 +543,7 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -609,7 +609,7 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 
     /**
@@ -675,6 +675,6 @@ class CorporationController extends ApiController
                 $this->applyFilters(request(), $sub_query);
             });
 
-        return Resource::collection($query->paginate());
+        return Resource::collection($query->paginate()->appends(request()->except('page')));
     }
 }

--- a/src/Http/Controllers/Api/v2/KillmailsController.php
+++ b/src/Http/Controllers/Api/v2/KillmailsController.php
@@ -85,7 +85,7 @@ class KillmailsController extends ApiController
                     $query->where('character_id', $character_id);
                 })->orWhereHas('attackers', function ($query) use ($character_id) {
                     $query->where('character_id', $character_id);
-                })->paginate()
+                })->paginate()->appends(request()->except('page'))
             );
     }
 
@@ -139,7 +139,7 @@ class KillmailsController extends ApiController
                 $query->where('corporation_id', $corporation_id);
             })->orWhereHas('attackers', function ($query) use ($corporation_id) {
                 $query->where('corporation_id', $corporation_id);
-            })->paginate()
+            })->paginate()->appends(request()->except('page'))
         );
     }
 

--- a/src/Http/Controllers/Api/v2/RoleController.php
+++ b/src/Http/Controllers/Api/v2/RoleController.php
@@ -78,7 +78,7 @@ class RoleController extends ApiController
     public function getIndex()
     {
 
-        return Resource::collection(Role::paginate());
+        return Resource::collection(Role::paginate()->appends(request()->except('page')));
     }
 
     /**

--- a/src/Http/Controllers/Api/v2/SquadController.php
+++ b/src/Http/Controllers/Api/v2/SquadController.php
@@ -68,7 +68,7 @@ class SquadController extends ApiController
      */
     public function index()
     {
-        return SquadResource::collection(Squad::paginate());
+        return SquadResource::collection(Squad::paginate()->appends(request()->except('page')));
     }
 
     /**

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -68,7 +68,7 @@ class UserController extends ApiController
      */
     public function getUsers()
     {
-        return UserResource::collection(User::paginate());
+        return UserResource::collection(User::paginate()->appends(request()->except('page')));
     }
 
     /**


### PR DESCRIPTION
this will append initially pass query filters to response metadata.

```
"links": {
    "first": "https://hostname/api/v2/character/industry/95221425?%24filter=activity_id%20eq%209&page=1",
    "last": "https://hostname/api/v2/character/industry/95221425?%24filter=activity_id%20eq%209&page=9",
    "prev": "https://hostname/api/v2/character/industry/95221425?%24filter=activity_id%20eq%209&page=1",
    "next": "https://hostname/api/v2/character/industry/95221425?%24filter=activity_id%20eq%209&page=3"
}
```

Closes eveseat/seat#863