### PR TITLE
fix: use correct tag for endpoint

### DIFF
--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Http/Controllers/Api/v2/UserController.php
+++ b/src/Http/Controllers/Api/v2/UserController.php
@@ -202,7 +202,7 @@ class UserController extends ApiController
             ],
         ],
         tags: [
-            'Squads',
+            'Users',
         ],
         parameters: [
             new OA\Parameter(name: 'user_id', description: 'A SeAT User ID', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),


### PR DESCRIPTION
I just noticed the user deletion endpoint is in the wrong documentation tab. This is because the tag has been set to the wrong value.

Is it a breaking change to change a tag? I think no since it is mainly used for the documentation, but I'm not sure.