### PR TITLE
fix: add ownership enforcement on character and corporation API endpoints

### DIFF
--- a/src/ApiServiceProvider.php
+++ b/src/ApiServiceProvider.php
@@ -26,6 +26,8 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Validator;
 use Seat\Api\Http\Middleware\ApiRequest;
 use Seat\Api\Http\Middleware\ApiToken;
+use Seat\Api\Http\Middleware\CharacterOwnership;
+use Seat\Api\Http\Middleware\CorporationOwnership;
 use Seat\Services\AbstractSeatPlugin;
 
 /**
@@ -104,6 +106,12 @@ class ApiServiceProvider extends AbstractSeatPlugin
 
         // Ensure incoming request is formed using JSON
         $router->aliasMiddleware('api.request', ApiRequest::class);
+
+        // Verify that the token owner has access to the requested character
+        $router->aliasMiddleware('api.character.ownership', CharacterOwnership::class);
+
+        // Verify that the token owner has access to the requested corporation
+        $router->aliasMiddleware('api.corporation.ownership', CorporationOwnership::class);
 
     }
 

--- a/src/Http/Middleware/CharacterOwnership.php
+++ b/src/Http/Middleware/CharacterOwnership.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Api\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Seat\Api\Models\ApiToken;
+
+/**
+ * Class CharacterOwnership.
+ *
+ * Ensures that the API token owner has access to the requested character_id.
+ *
+ * Tokens with no associated user (user_id is null) are treated as superuser-scoped
+ * tokens with unrestricted access to all characters. Tokens linked to a specific
+ * user may only access character_ids belonging to that user, unless that user has
+ * the superuser role.
+ *
+ * @package Seat\Api\Http\Middleware
+ */
+class CharacterOwnership
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $character_id = $request->route('character_id');
+
+        // If there is no character_id in the route, pass through.
+        if (is_null($character_id)) {
+            return $next($request);
+        }
+
+        $token = ApiToken::where('token', $request->header('X-Token'))->first();
+
+        // Token not found — the api.auth middleware will already have rejected
+        // this request, but we guard defensively here as well.
+        if (is_null($token)) {
+            return response()->json('Unauthorized', 401);
+        }
+
+        // Tokens with no associated user are superuser-scoped (unrestricted).
+        if (is_null($token->user_id)) {
+            return $next($request);
+        }
+
+        $user = $token->user;
+
+        // Superusers have unrestricted access to all characters.
+        if ($user->hasSuperUser()) {
+            return $next($request);
+        }
+
+        $ownedCharacterIds = $user->characters->pluck('character_id');
+
+        if (! $ownedCharacterIds->contains((int) $character_id)) {
+            return response()->json([
+                'error' => 'Access to this character is not authorized.',
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/CorporationOwnership.php
+++ b/src/Http/Middleware/CorporationOwnership.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Api\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Seat\Api\Models\ApiToken;
+
+/**
+ * Class CorporationOwnership.
+ *
+ * Ensures that the API token owner has access to the requested corporation_id.
+ *
+ * A user is considered to have access to a corporation if at least one of their
+ * characters belongs to that corporation. Tokens with no associated user
+ * (user_id is null) are treated as superuser-scoped tokens with unrestricted
+ * access. Tokens linked to a specific user with the superuser role also retain
+ * unrestricted access.
+ *
+ * @package Seat\Api\Http\Middleware
+ */
+class CorporationOwnership
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $corporation_id = $request->route('corporation_id');
+
+        // If there is no corporation_id in the route, pass through.
+        if (is_null($corporation_id)) {
+            return $next($request);
+        }
+
+        $token = ApiToken::where('token', $request->header('X-Token'))->first();
+
+        // Token not found — the api.auth middleware will already have rejected
+        // this request, but we guard defensively here as well.
+        if (is_null($token)) {
+            return response()->json('Unauthorized', 401);
+        }
+
+        // Tokens with no associated user are superuser-scoped (unrestricted).
+        if (is_null($token->user_id)) {
+            return $next($request);
+        }
+
+        $user = $token->user;
+
+        // Superusers have unrestricted access to all corporations.
+        if ($user->hasSuperUser()) {
+            return $next($request);
+        }
+
+        // A user has access to a corporation if at least one of their characters
+        // is a member of that corporation.
+        $userCorporationIds = $user->characters
+            ->map(function ($character) {
+                return optional($character->affiliation)->corporation_id;
+            })
+            ->filter()
+            ->unique()
+            ->values();
+
+        if (! $userCorporationIds->contains((int) $corporation_id)) {
+            return response()->json([
+                'error' => 'Access to this corporation is not authorized.',
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -107,7 +107,7 @@ Route::group([
                 Route::get('/{killmail_id}')->uses('KillmailsController@getDetail');
             });
 
-            Route::group(['prefix' => 'character'], function () {
+            Route::group(['prefix' => 'character', 'middleware' => 'api.character.ownership'], function () {
 
                 Route::get('/assets/{character_id}')->uses('CharacterController@getAssets');
                 Route::get('/contacts/{character_id}')->uses('CharacterController@getContacts');
@@ -126,7 +126,7 @@ Route::group([
                 Route::get('/notifications/{character_id}')->uses('CharacterController@getNotifications');
             });
 
-            Route::group(['prefix' => 'corporation'], function () {
+            Route::group(['prefix' => 'corporation', 'middleware' => 'api.corporation.ownership'], function () {
 
                 Route::get('/assets/{corporation_id}')->uses('CorporationController@getAssets');
                 Route::get('/contacts/{corporation_id}')->uses('CorporationController@getContacts');

--- a/src/Models/ApiToken.php
+++ b/src/Models/ApiToken.php
@@ -23,6 +23,7 @@
 namespace Seat\Api\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Web\Models\User;
 
 /**
  * Class ApiToken.
@@ -34,7 +35,7 @@ class ApiToken extends Model
     /**
      * @var array
      */
-    protected $fillable = ['token', 'allowed_src', 'comment'];
+    protected $fillable = ['token', 'allowed_src', 'comment', 'user_id'];
 
     /**
      * Make sure we cleanup logs on delete.
@@ -61,5 +62,19 @@ class ApiToken extends Model
     {
 
         return $this->hasMany(ApiTokenLog::class);
+    }
+
+    /**
+     * Return the user that owns this token, if any.
+     *
+     * Tokens with no associated user (user_id is null) are considered
+     * superuser-scoped tokens with unrestricted access.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user()
+    {
+
+        return $this->belongsTo(User::class);
     }
 }

--- a/src/database/migrations/2024_01_01_000000_add_user_id_to_api_tokens_table.php
+++ b/src/database/migrations/2024_01_01_000000_add_user_id_to_api_tokens_table.php
@@ -20,35 +20,37 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Seat\Api\Http\Validation;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
-use Illuminate\Foundation\Http\FormRequest;
-
-class NewToken extends FormRequest
+class AddUserIdToApiTokensTable extends Migration
 {
     /**
-     * Authorize the request by default.
+     * Run the migrations.
      *
-     * @return bool
+     * @return void
      */
-    public function authorize()
+    public function up()
     {
-
-        return true;
+        Schema::table('api_tokens', function (Blueprint $table) {
+            // Nullable so that existing tokens (which have no associated user)
+            // are treated as superuser-scoped (unrestricted) tokens.
+            $table->unsignedBigInteger('user_id')->nullable()->after('comment');
+            $table->index('user_id');
+        });
     }
 
     /**
-     * Get the validation rules that apply to the request.
+     * Reverse the migrations.
      *
-     * @return array
+     * @return void
      */
-    public function rules()
+    public function down()
     {
-
-        return [
-            'comment' => 'max:255',
-            'allowed_src' => 'required|ip',
-            'user_id' => 'nullable|integer|exists:users,id',
-        ];
+        Schema::table('api_tokens', function (Blueprint $table) {
+            $table->dropIndex(['user_id']);
+            $table->dropColumn('user_id');
+        });
     }
 }


### PR DESCRIPTION
## Security Fix: Insecure Direct Object Reference (IDOR) on Character/Corporation Endpoints

### Vulnerability

The character and corporation API endpoints accepted any valid `character_id` or `corporation_id` as a route parameter without verifying that the authenticated API token's owner has access to that resource.

Any holder of a valid API token — regardless of which characters they own — could access the data of **any** character or corporation registered on the SeAT instance by enumerating or guessing EVE character IDs (which are public and sequential).

### Affected Endpoints

All routes under:
- `GET /api/v2/character/{character_id}/*` — assets, wallet, mail, contracts, skills, market orders, notifications, industry jobs, jump clones, contacts, etc.
- `GET /api/v2/corporation/{corporation_id}/*` — assets, wallet, member tracking, contracts, etc.

### Impact

An attacker with any valid API token (even one generated for a non-privileged user) can:

- Read the complete wallet history and ISK balance of any character on the instance
- Access private in-game mail of any character
- Retrieve asset locations and values for any character or corporation
- Access market orders, industry jobs, and contract details
- Track member locations via corporation member tracking endpoints

In an alliance context where SeAT is used for auth and intel, this constitutes a full compromise of all member financial and operational data.

### Fix

Added `CharacterOwnership` and `CorporationOwnership` middleware classes that intercept requests to character/corporation-scoped endpoints and verify that the requesting token's owner has access to the requested resource.

A nullable `user_id` column is added to `api_tokens` via a new migration, allowing tokens to be scoped to a specific SeAT user. Backwards compatibility is preserved: existing tokens with no `user_id` are treated as superuser-scoped and retain unrestricted access. Users with the superuser role also retain unrestricted access to support administrative use cases.

### References

- [OWASP: Insecure Direct Object Reference (IDOR)](https://owasp.org/www-community/attacks/Insecure_Direct_Object_References)
- [OWASP: Broken Object Level Authorization (API Security Top 10 #1)](https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/)
- [CWE-639: Authorization Bypass Through User-Controlled Key](https://cwe.mitre.org/data/definitions/639.html)
- [PortSwigger: IDOR vulnerabilities](https://portswigger.net/web-security/access-control/idor)